### PR TITLE
Feat: add qrcode component as image

### DIFF
--- a/apps/web/src/components/qr/index.tsx
+++ b/apps/web/src/components/qr/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface QrProps {
+  url: string;
+  width?: string;
+  height?: string;
+  borderRadius?: string;
+}
+
+const Qr = ({
+  url,
+  width = '100%',
+  height = '100%',
+  borderRadius = '0px',
+}: QrProps) => {
+  const imageStyle: React.CSSProperties = {
+    maxWidth: width,
+    maxHeight: height,
+    borderRadius: borderRadius,
+  };
+
+  return <img src={url} alt="qr image" style={imageStyle} />;
+};
+
+export default Qr;


### PR DESCRIPTION
Added `Qr` component as Image

This is not legal (see code), but I have not been able to create a real QR, in the future it will obviously be replaced, but for the moment since the QR will be static it can be an option.