### PR TITLE
fix: `who follow` section

### DIFF
--- a/apps/web/app/components/Component.WhoFollow.tsx
+++ b/apps/web/app/components/Component.WhoFollow.tsx
@@ -43,13 +43,14 @@ export default function WhoFollow() {
 
         if (following) {
           following.following.forEach((user: any) => {
+            const id = user.uri.replace('pubky:', '');
             if (
               Array.isArray(hotFollowed) &&
-              hotFollowed.some((followed: any) => followed.uri === user.uri)
+              hotFollowed.some((followed: any) => followed.id === id)
             ) {
               setFollowedUser((prevState) => ({
                 ...prevState,
-                [user.uri]: true,
+                [id]: true,
               }));
             }
           });


### PR DESCRIPTION
I noticed that using `uri` the component stops working and the button state is incorrect, using `id` instead resolves the error.

```
 useEffect(() => {
    async function fetchFollowing() {
      try {
        if (!pubky) return;

        const following = await listFollowing(pubky);

        if (following) {
          following.following.forEach((user: any) => {
            const id = user.uri.replace('pubky:', '');
            if (
              Array.isArray(hotFollowed) &&
              hotFollowed.some((followed: any) => followed.id === id)
            ) {
              setFollowedUser((prevState) => ({
                ...prevState,
                [id]: true,
              }));
            }
          });
        }
      } catch (error) {
        console.log(error);
      }
    }

    fetchFollowing();
  }, [pubky, listFollowing, hotFollowed]);
```