### PR TITLE
fix: profile sidebar

### DIFF
--- a/apps/web/app/profile/components/Profile.Sidebar.tsx
+++ b/apps/web/app/profile/components/Profile.Sidebar.tsx
@@ -223,7 +223,7 @@ export default function Sidebar({
             {initLoadingFollowed ? (
               <Button.Medium
                 loading={initLoadingFollowed}
-                className={!creatorPubky ? 'hidden' : ''}
+                className={creatorPubky === pubky ? 'hidden' : ''}
               >
                 Loading
               </Button.Medium>
@@ -234,7 +234,7 @@ export default function Sidebar({
                 loading={loadingFollowed}
                 variant="default"
                 icon={<Icon.UserMinus size="16" />}
-                className={!creatorPubky ? 'hidden' : ''}
+                className={creatorPubky === pubky ? 'hidden' : ''}
               >
                 Unfollow
               </Button.Medium>
@@ -245,7 +245,7 @@ export default function Sidebar({
                 loading={loadingFollowed}
                 variant="default"
                 icon={<Icon.UserPlus size="16" />}
-                className={!creatorPubky ? 'hidden' : ''}
+                className={creatorPubky === pubky ? 'hidden' : ''}
               >
                 Follow
               </Button.Medium>


### PR DESCRIPTION
In the last PR, in `profile/[creatorPubky] `I modified the code to always pass creatorPubky to it in such a way as to then have `followers/[creatorPubky]`, `following/[creatorPubky]` that can also be visited by the user himself with the aim of being able to share

![Screenshot 2024-04-30 160849](https://github.com/synonymdev/pubky-app/assets/63161412/35941cc7-6ca6-434c-a007-f251b2febc54)


However, I forgot to change the code so show the `Follow` button on your personal profile too for now