### PR TITLE
fix: headerHotTags/timestampNow

### DIFF
--- a/apps/web/app/hot-tags/page.tsx
+++ b/apps/web/app/hot-tags/page.tsx
@@ -130,7 +130,7 @@ export default function Index() {
 
   return (
     <Content.Main>
-      <Header className="hidden md:block" title="Hot&nbsp;Tags" />
+      <Header className="hidden md:block" title="HotTags" />
       <Content.Grid className='flex w-full justify-between items-start inline-flex"'>
         <div className="w-full flex-col inline-flex gap-3">
           <div className="flex gap-6 mb-6">

--- a/apps/web/components/Modal/_Repost.tsx
+++ b/apps/web/components/Modal/_Repost.tsx
@@ -221,7 +221,7 @@ export default function Repost({
               maxLength={300}
               autoFocus
               className={`w-full h-auto mt-4`}
-              placeholder="What's on your mind?"
+              placeholder="Add a comment"
             />
             {videoId && (
               <div className="relative w-full border border-stone-800 hover:border-stone-700 mt-4 rounded-xl overflow-hidden">

--- a/apps/web/components/Post/index.tsx
+++ b/apps/web/components/Post/index.tsx
@@ -107,7 +107,7 @@ export default function Post({
               ) : (
                 <>
                   <PostUI.RepostCard
-                    className="relative z-10"
+                    className="relative z-50"
                     onClick={(event) => event.stopPropagation()}
                   >
                     <Icon.Repost size="16" />

--- a/apps/web/components/_Header.tsx
+++ b/apps/web/components/_Header.tsx
@@ -177,7 +177,7 @@ export default function Header({ title, className }: HeaderProps) {
           <Button.Action
             variant="menu"
             label="Hot&#160;Tags"
-            active={title === `Hot Tags`}
+            active={title === `HotTags`}
             icon={<Icon.Tag size="24" />}
           />
         </Link>

--- a/apps/web/utils/_timeAgo.ts
+++ b/apps/web/utils/_timeAgo.ts
@@ -7,6 +7,10 @@ export function timeAgo(timestamp: number) {
     (new Date().getTime() - new Date(date).getTime()) / 1000
   );
 
+  if (seconds < 10) {
+    return 'Now';
+  }
+
   let interval = seconds / 31536000;
   let number = Math.floor(interval);
 


### PR DESCRIPTION
If you go to the HotTags page the menu icon does not remain active, I have removed the space for the moment