### PR TITLE
fix: manage height tweet

### DIFF
--- a/libs/ui-shared/src/lib/Post/_Content.tsx
+++ b/libs/ui-shared/src/lib/Post/_Content.tsx
@@ -160,7 +160,7 @@ export const Content = ({ children, text }: ContentProps) => {
         <LinkPreview url={preview} />
       )}
       {tweetId && (
-        <div className="flex overflow-hidden justify-start -mt-2 -mb-6">
+        <div className="no-scrollbar my-4 max-h-[500px] w-full max-w-[384px] overflow-y-auto">
           <Tweet id={tweetId} />
         </div>
       )}


### PR DESCRIPTION
@MiguelMedeiros I tried using` transform: scale(0.5)` but without success, I put `max-w` and `max-h`, try. This is the best result I was able to obtain


![Screenshot 2024-07-08 192511](https://github.com/pubky/pubky-app/assets/63161412/fd03a961-0d32-490b-8f71-6f4d250023c2)
![Screenshot 2024-07-08 192531](https://github.com/pubky/pubky-app/assets/63161412/b5764494-f4a2-4cd7-802d-1e67ca61bd31)
