### PR TITLE
feat: add E2E test automated workflow

### DIFF
--- a/.github/workflows/e2e-test-no-matrix.yml
+++ b/.github/workflows/e2e-test-no-matrix.yml
@@ -1,4 +1,4 @@
-name: e2e-test
+name: e2e-test-no-matrix
 
 on:
   workflow_dispatch:
@@ -7,9 +7,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        browser: [chrome, firefox]
 
     steps:
       - name: Checkout this repository
@@ -39,28 +36,55 @@ jobs:
           npm install
           npm link @pubky/sdk
 
-      - name: Run e2e tests (${{ matrix.browser }})
+      - name: Run e2e tests (chrome)
         uses: cypress-io/github-action@v6
         with:
           working-directory: pubky-app/apps/web-e2e
           config-file: cypress.config.ts
           spec: src/e2e/auth.cy.ts
-          browser: ${{ matrix.browser }}
-          summary-title: ${{ matrix.browser }}
+          browser: chrome
+          summary-title: 'Chrome'
           install: false
           start: npm run start:dev
           wait-on: 'http://localhost:4200'
 
-      - name: Upload ${{ matrix.browser }} screenshots
+      - name: Upload chrome screenshots
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: screenshots-${{ matrix.browser }}
+          name: screenshots-chrome
           path: pubky-app/dist/cypress/apps/web-e2e/screenshots
 
-      - name: Upload ${{ matrix.browser }} videos
+      - name: Upload chrome videos
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: videos-${{ matrix.browser }}
+          name: videos-chrome
+          path: pubky-app/dist/cypress/apps/web-e2e/videos
+
+      - name: Run e2e tests (firefox)
+        if: ${{ always() }}
+        uses: cypress-io/github-action@v6
+        with:
+          working-directory: pubky-app/apps/web-e2e
+          config-file: cypress.config.ts
+          spec: src/e2e/auth.cy.ts
+          browser: firefox
+          summary-title: 'Firefox'
+          install: false
+          start: npm run start:dev
+          wait-on: 'http://localhost:4200'
+
+      - name: Upload firefox screenshots
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-firefox
+          path: pubky-app/dist/cypress/apps/web-e2e/screenshots
+
+      - name: Upload firefox videos
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: videos-firefox
           path: pubky-app/dist/cypress/apps/web-e2e/videos

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -48,7 +48,7 @@ jobs:
           browser: ${{ matrix.browser }}
           summary-title: ${{ matrix.browser }}
           install: false
-          start: npm run start:dev
+          start: npm run start:prod
           wait-on: 'http://localhost:4200'
 
       - name: Upload ${{ matrix.browser }} screenshots

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        browser: [chrome, firefox]
 
     steps:
       - name: Checkout this repository
@@ -29,22 +32,6 @@ jobs:
           cp ./.env.example ./services/backend/.env
           npm run backend &
 
-      # todo: run in prod mode
-      # - name: Run pubky-app frontend
-      #   working-directory: pubky-app
-      #   run: |
-      #     cp ./.env.example ./.env
-      #     npm install
-      #     npm link @pubky/sdk
-      #     npm run start:dev &
-
-      # - name: Wait for services to start
-      #   run: sleep 5
-
-      # - name: Run e2e tests
-      #   working-directory: pubky-app/apps/web-e2e
-      #   run: npx cypress run --browser chrome
-
       - name: Build pubky-app frontend
         working-directory: pubky-app
         run: |
@@ -52,27 +39,81 @@ jobs:
           npm install
           npm link @pubky/sdk
 
-      - name: Run e2e tests
+      - name: Run e2e tests (${{ matrix.browser }})
         uses: cypress-io/github-action@v6
         with:
           working-directory: pubky-app/apps/web-e2e
           config-file: cypress.config.ts
           spec: src/e2e/auth.cy.ts
-          browser: chrome
+          browser: ${{ matrix.browser }}
+          summary-title: ${{ matrix.browser }}
           install: false
           start: npm run start:dev
           wait-on: 'http://localhost:4200'
 
-      - name: Upload screenshots
+      - name: Upload ${{ matrix.browser }} screenshots
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: screenshots
+          name: screenshots-${{ matrix.browser }}
           path: pubky-app/dist/cypress/apps/web-e2e/screenshots
 
-      - name: Upload videos
+      - name: Upload ${{ matrix.browser }} videos
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: videos
+          name: videos-${{ matrix.browser }}
           path: pubky-app/dist/cypress/apps/web-e2e/videos
+
+      # - name: Run e2e tests (chrome)
+      #   uses: cypress-io/github-action@v6
+      #   with:
+      #     working-directory: pubky-app/apps/web-e2e
+      #     config-file: cypress.config.ts
+      #     spec: src/e2e/auth.cy.ts
+      #     browser: chrome
+      #     summary-title: 'Chrome'
+      #     install: false
+      #     start: npm run start:dev
+      #     wait-on: 'http://localhost:4200'
+
+      # - name: Upload chrome screenshots
+      #   if: ${{ always() }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: screenshots-chrome
+      #     path: pubky-app/dist/cypress/apps/web-e2e/screenshots
+
+      # - name: Upload chrome videos
+      #   if: ${{ always() }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: videos-chrome
+      #     path: pubky-app/dist/cypress/apps/web-e2e/videos
+
+      # - name: Run e2e tests (firefox)
+      #   if: ${{ always() }}
+      #   uses: cypress-io/github-action@v6
+      #   with:
+      #     working-directory: pubky-app/apps/web-e2e
+      #     config-file: cypress.config.ts
+      #     spec: src/e2e/auth.cy.ts
+      #     browser: firefox
+      #     summary-title: 'Firefox'
+      #     install: false
+      #     start: npm run start:dev
+      #     wait-on: 'http://localhost:4200'
+
+      # - name: Upload firefox screenshots
+      #   if: ${{ always() }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: screenshots-firefox
+      #     path: pubky-app/dist/cypress/apps/web-e2e/screenshots
+
+      # - name: Upload firefox videos
+      #   if: ${{ always() }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: videos-firefox
+      #     path: pubky-app/dist/cypress/apps/web-e2e/videos

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,78 @@
+name: e2e-test
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v4
+        with:
+          path: pubky-app
+
+      - name: Checkout skunk-works
+        uses: actions/checkout@v4
+        with:
+          repository: pubky/skunk-works
+          path: skunk-works
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Run skunk-works
+        working-directory: skunk-works
+        run: |
+          npm install
+          npm run link
+          cp ./.env.example ./services/backend/.env
+          npm run backend &
+
+      # todo: run in prod mode
+      # - name: Run pubky-app frontend
+      #   working-directory: pubky-app
+      #   run: |
+      #     cp ./.env.example ./.env
+      #     npm install
+      #     npm link @pubky/sdk
+      #     npm run start:dev &
+
+      # - name: Wait for services to start
+      #   run: sleep 5
+
+      # - name: Run e2e tests
+      #   working-directory: pubky-app/apps/web-e2e
+      #   run: npx cypress run --browser chrome
+
+      - name: Build pubky-app frontend
+        working-directory: pubky-app
+        run: |
+          cp ./.env.example ./.env
+          npm install
+          npm link @pubky/sdk
+
+      - name: Run e2e tests
+        uses: cypress-io/github-action@v6
+        with:
+          working-directory: pubky-app/apps/web-e2e
+          config-file: cypress.config.ts
+          spec: src/e2e/auth.cy.ts
+          browser: chrome
+          install: false
+          start: npm run start:dev
+          wait-on: 'http://localhost:4200'
+
+      - name: Upload screenshots
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: pubky-app/dist/cypress/apps/web-e2e/screenshots
+
+      - name: Upload videos
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: videos
+          path: pubky-app/dist/cypress/apps/web-e2e/videos

--- a/apps/web-e2e/cypress.config.ts
+++ b/apps/web-e2e/cypress.config.ts
@@ -6,5 +6,7 @@ export default defineConfig({
   e2e: {
     ...nxE2EPreset(__filename, { cypressDir: 'src' }),
     baseUrl: 'http://localhost:4200',
+    defaultCommandTimeout: 30_000,
+    video: true
   },
 });

--- a/apps/web-e2e/cypress.config.ts
+++ b/apps/web-e2e/cypress.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   e2e: {
     ...nxE2EPreset(__filename, { cypressDir: 'src' }),
     baseUrl: 'http://localhost:4200',
-    defaultCommandTimeout: 30_000,
+    defaultCommandTimeout: process.env.CI ? 30_000 : 4000,
     video: true
   },
 });

--- a/apps/web-e2e/src/e2e/auth.cy.ts
+++ b/apps/web-e2e/src/e2e/auth.cy.ts
@@ -3,7 +3,7 @@ import path = require('path');
 
 describe('onboarding', () => {
   beforeEach(() => {
-    cy.viewport(1920, 1080);
+    cy.viewport(1280, 720); //cy.viewport(1920, 1080);
   });
 
   it('should onboard a new user, go to home and logout', () => {

--- a/apps/web-e2e/src/e2e/auth.cy.ts
+++ b/apps/web-e2e/src/e2e/auth.cy.ts
@@ -7,7 +7,7 @@ describe('onboarding', () => {
     cy.viewport(1920, 1080);
     slowCypressDown(200);
     // workaround the issue of page content not always loading on first visit
-    cy.visit('/onboarding');
+    //cy.visit('/onboarding');
   });
 
   it('should onboard a new user, go to home and logout', () => {

--- a/apps/web-e2e/src/e2e/auth.cy.ts
+++ b/apps/web-e2e/src/e2e/auth.cy.ts
@@ -1,57 +1,85 @@
+import moment = require('moment');
+import path = require('path');
+
 describe('onboarding', () => {
   beforeEach(() => {
     cy.viewport(1920, 1080);
   });
 
   it('should onboard a new user, go to home and logout', () => {
-    cy.visit('/onboarding');
-
-    cy.get('#onboarding-sign-in-link').click();
-    cy.location('pathname').should('eq', '/onboarding/sign-in');
-
-    cy.get('#onboarding-sign-up-link').click();
-    cy.location('pathname').should('eq', '/onboarding/sign-up');
-
-    cy.get('#onboarding-name-input').type('Satoshi Nakamoto');
-    cy.get('#onboarding-recovery-password-input').type('password');
-
-    cy.get('#onboarding-submit-button').click();
-    cy.location('pathname').should('eq', '/onboarding/confirm');
-
-    cy.get('#onboarding-start-button').click();
-    cy.location('pathname').should('eq', '/home');
-
-    cy.visit('/logout');
-    cy.location('pathname').should('eq', '/logout');
-
-    cy.get('#logout-link').click();
-    cy.location('pathname').should('eq', '/onboarding/sign-in');
+    onboardAsNewUser('Satoshi Nakamoto', 'I am cypherpunk');
+    signOut(false);
   });
 
-  it('should login with a recovery file and logout', () => {
-    cy.visit('/onboarding');
+  it('should login, save recovery file and use it to log back in', () => {
+    const username = 'satoshin';
+    onboardAsNewUser(username)
 
-    cy.get('#onboarding-sign-in-link').click();
-    cy.location('pathname').should('eq', '/onboarding/sign-in');
+    // backup recovery file
+    cy.get('#remind-backup-now-btn').click();
+    cy.get('#backup-recovery-file-btn').click();
+    cy.get('#backup-recovery-file-password-input').type('123456');
+    cy.get('#backup-download-recovery-file-btn').click();
 
-    cy.get('#onboarding-password-input').type('password');
-    cy.get('#file_input').selectFile(
-      'cypress/downloads/recovery_file_2024-05-01.pkarr'
+    // verify backup file
+    const downloadsFolder = Cypress.config('downloadsFolder');
+    const expectedFileName = `pubky_recovery_${moment().format('YYYY-MM-DD')}.pkarr`;
+    const expectedFilePath = path.join(downloadsFolder, expectedFileName);
+    cy.readFile(expectedFilePath).should('exist');
+
+    signOut(true);
+
+    cy.location('pathname').should('eq', '/sign-in');
+
+    cy.get('#fileInput').selectFile(expectedFilePath,
+      { force: true } // force to bypass visibility check of hidden input field
     );
+    cy.get('#onboarding-password-input').type('123456');
 
     cy.get('#onboarding-sign-in-button').click();
-    cy.location('pathname').should('eq', '/onboarding/permissions');
 
-    cy.get('#onboarding-permissions-link').click();
-    cy.location('pathname').should('eq', '/onboarding/welcome');
+    cy.get('#header-profile-pic').click();
+    cy.location('pathname').should('eq', '/profile');
+    cy.get('#profile-username-header').invoke('text').should('eq', username);
+  });
+});
 
-    cy.get('#onboarding-welcome-link').click();
-    cy.location('pathname').should('eq', '/home');
+// todo: move to shared helpers file
+const onboardAsNewUser = (profileName, profileBio = '') => {
+  cy.visit('/onboarding');
 
-    cy.visit('/logout');
+  cy.get('#onboarding-get-started-link').click();
+  cy.location('pathname').should('eq', '/onboarding/sign-in');
+
+  cy.get('#onboarding-sign-up-link').click();
+  cy.location('pathname').should('eq', '/onboarding/sign-up');
+
+  cy.get('#onboarding-name-input').type(profileName);
+  profileBio ? cy.get('#onboarding-bio-input').type(profileBio) : null;
+
+  cy.get('#onboarding-submit-button').click();
+
+  cy.location('pathname').should('eq', '/onboarding/pubky');
+  
+  cy.get('#onboarding-confirm-link').click();
+
+  cy.location('pathname').should('eq', '/onboarding/confirm');
+  
+  cy.get('#onboarding-start-exploring-btn').click();
+  cy.location('pathname').should('eq', '/home');
+};
+
+const signOut = (hasBackedUp) => {
+    cy.get('#header-profile-pic').click();
+    cy.location('pathname').should('eq', '/profile');
+
+    cy.get('#profile-sign-out-btn').click();
+
+    // sign out model only shows if user has not backed up recovery file
+    if (!hasBackedUp) cy.get('#logout-modal-sign-out-btn').click();
+
     cy.location('pathname').should('eq', '/logout');
 
     cy.get('#logout-link').click();
-    cy.location('pathname').should('eq', '/onboarding/sign-in');
-  });
-});
+    cy.location('pathname').should('eq', '/sign-in');
+};

--- a/apps/web-e2e/src/e2e/auth.cy.ts
+++ b/apps/web-e2e/src/e2e/auth.cy.ts
@@ -1,9 +1,13 @@
 import moment = require('moment');
 import path = require('path');
+import { slowCypressDown } from 'cypress-slow-down'
 
 describe('onboarding', () => {
   beforeEach(() => {
-    cy.viewport(1280, 720); //cy.viewport(1920, 1080);
+    cy.viewport(1920, 1080);
+    slowCypressDown(200);
+    // workaround the issue of page content not always loading on first visit
+    cy.visit('/onboarding');
   });
 
   it('should onboard a new user, go to home and logout', () => {
@@ -35,8 +39,9 @@ describe('onboarding', () => {
       { force: true } // force to bypass visibility check of hidden input field
     );
     cy.get('#onboarding-password-input').type('123456');
-
     cy.get('#onboarding-sign-in-button').click();
+
+    cy.location('pathname').should('eq', '/home');
 
     cy.get('#header-profile-pic').click();
     cy.location('pathname').should('eq', '/profile');

--- a/apps/web-e2e/src/support/commands.ts
+++ b/apps/web-e2e/src/support/commands.ts
@@ -38,6 +38,6 @@ Cypress.Commands.add('login', (email, password) => {
 // `Uncaught SyntaxError: Invalid or unexpected token` on Chrome, and
 // `Uncaught SyntaxError: "" literal not terminated before end of script` on firefox.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-Cypress.on('uncaught:exception', (_err, _runnable) => {
-  return false
-})
+// Cypress.on('uncaught:exception', (_err, _runnable) => {
+//   return false
+// })

--- a/apps/web-e2e/src/support/commands.ts
+++ b/apps/web-e2e/src/support/commands.ts
@@ -33,3 +33,11 @@ Cypress.Commands.add('login', (email, password) => {
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+// To prevent Cypress from failing the test when:
+// `Uncaught SyntaxError: Invalid or unexpected token` on Chrome, and
+// `Uncaught SyntaxError: "" literal not terminated before end of script` on firefox.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+Cypress.on('uncaught:exception', (_err, _runnable) => {
+  return false
+})

--- a/apps/web/app/onboarding/confirm/page.tsx
+++ b/apps/web/app/onboarding/confirm/page.tsx
@@ -160,7 +160,7 @@ export default function Index() {
             )}
           </Tooltip.RootSmall>
           <Link href="/home">
-            <Button.Large icon={<Icon.Check />} className="w-[170px] z-20">
+            <Button.Large id="onboarding-start-exploring-btn" icon={<Icon.Check />} className="w-[170px] z-20">
               Start Exploring
             </Button.Large>
           </Link>

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -58,7 +58,7 @@ export default function Index() {
     <Content.Main background="bg-black" className="pb-0">
       <Header.Root>
         <Header.Logo link={logoLink} />
-        <Header.Action>Sign in</Header.Action>
+        <Header.Action id="onboarding-sign-in-btn">Sign in</Header.Action>
       </Header.Root>
       <Content.Grid>
         <Typography.Display>Become the algorithm</Typography.Display>
@@ -66,7 +66,7 @@ export default function Index() {
           Your keys, your content, your rules. Social publishing, reimagined.
         </Typography.H2>
         <div className="relative flex gap-3">
-          <Link id="onboarding-sign-in-link" href="/onboarding/sign-in">
+          <Link id="onboarding-get-started-link" href="/onboarding/sign-in">
             <Button.Large className="mt-12 relative z-20">
               Let&apos;s get started
             </Button.Large>

--- a/apps/web/app/onboarding/pubky/page.tsx
+++ b/apps/web/app/onboarding/pubky/page.tsx
@@ -64,7 +64,7 @@ export default function Index() {
         >
           Copy pubky to clipboard
         </Button.Large>
-        <Link href="/onboarding/confirm">
+        <Link id = "onboarding-confirm-link" href="/onboarding/confirm">
           <Button.Large icon={<Icon.ArrowRight />} className="w-[140px] z-20">
             Continue
           </Button.Large>

--- a/apps/web/app/profile/components/Handle/_Buttons.tsx
+++ b/apps/web/app/profile/components/Handle/_Buttons.tsx
@@ -128,6 +128,7 @@ export default function Buttons({
       {(!creatorPubky || creatorPubky === pubky) && (
         <>
           <Button.Medium
+            id="profile-sign-out-btn"
             className="px-3 w-21 h-8"
             onClick={
               disposableAccount
@@ -139,6 +140,7 @@ export default function Buttons({
             Sign out
           </Button.Medium>
           <Button.Medium
+            id="profile-edit-btn"
             className="px-3 w-auto h-8"
             onClick={() => router.push('/settings/edit')}
             icon={<Icon.Pencil size="16" />}
@@ -148,6 +150,7 @@ export default function Buttons({
         </>
       )}
       <Button.Medium
+        id="profile-copy-pubkey-btn"
         className="px-3 w-auto h-8"
         onClick={() => {
           setContent(`pk:${pubkey}`, 'pubky');
@@ -159,6 +162,7 @@ export default function Buttons({
         {Utils.minifyPubky(pubkey)}
       </Button.Medium>
       <Button.Medium
+        id="profile-copy-link-btn"
         className="px-3 w-auto h-8"
         onClick={() => {
           setContent(`${window.location.origin}/profile/${pubkey}`, 'link');

--- a/apps/web/app/profile/components/Handle/index.tsx
+++ b/apps/web/app/profile/components/Handle/index.tsx
@@ -73,7 +73,7 @@ export default function Handle({
     <div {...rest} className={twMerge(rest.className)}>
       {username && pubkey ? (
         <>
-          <Typography.Display className="text-left">
+          <Typography.Display id='profile-username-header' className="text-left">
             {Utils.minifyText(username.toString(), 15)}
           </Typography.Display>
           <div className="-mt-4 inline-flex flex-row gap-3">

--- a/apps/web/components/Header/index.tsx
+++ b/apps/web/components/Header/index.tsx
@@ -212,13 +212,14 @@ export default function Header({ title, className }: HeaderProps) {
             icon={<Icon.GearSix size="24" />}
           />
         </Link>
-        <Link id="header-profile-pic-link" href="/profile" className="w-[48px] relative">
+        <Link href="/profile" className="w-[48px] relative">
           {notifications.length !== 0 && (
             <PostUtil.Counter className="w-6 h-6 absolute text-center bottom-0 right-0 bg-black bg-opacity-60 border-fuchsia-500 border-opacity-100">
               {notifications.length}
             </PostUtil.Counter>
           )}
           <ImageByUri
+            id="header-profile-pic"
             width={48}
             height={48}
             className={`rounded-full w-[48px] h-[48px]`}

--- a/apps/web/components/Header/index.tsx
+++ b/apps/web/components/Header/index.tsx
@@ -178,6 +178,7 @@ export default function Header({ title, className }: HeaderProps) {
       <div className="hidden lg:flex gap-4 items-center">
         <Link href="/home">
           <Button.Action
+            id="header-home-btn"
             variant="menu"
             //label="Feed"
             active={title === 'Feed'}
@@ -186,6 +187,7 @@ export default function Header({ title, className }: HeaderProps) {
         </Link>
         <Link href="/hot-tags">
           <Button.Action
+            id="header-hot-tags-btn"
             variant="menu"
             label="Hot&#160;Tags"
             active={title === `HotTags`}
@@ -194,6 +196,7 @@ export default function Header({ title, className }: HeaderProps) {
         </Link>
         <Link href="/bookmarks">
           <Button.Action
+            id="header-bookmarks-btn"
             variant="menu"
             label="Bookmarks"
             active={title === 'Bookmarks'}
@@ -202,13 +205,14 @@ export default function Header({ title, className }: HeaderProps) {
         </Link>
         <Link href="/settings">
           <Button.Action
+            id="header-settings-btn"
             variant="menu"
             label="Settings"
             active={title === 'Settings'}
             icon={<Icon.GearSix size="24" />}
           />
         </Link>
-        <Link href="/profile" className="w-[48px] relative">
+        <Link id="header-profile-pic-link" href="/profile" className="w-[48px] relative">
           {notifications.length !== 0 && (
             <PostUtil.Counter className="w-6 h-6 absolute text-center bottom-0 right-0 bg-black bg-opacity-60 border-fuchsia-500 border-opacity-100">
               {notifications.length}

--- a/apps/web/components/ImageByUri/index.tsx
+++ b/apps/web/components/ImageByUri/index.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useClientContext } from '@/contexts';
 
 interface ImageByUriProps {
+  id?: string;
   uri: string | File | undefined;
   alt: string;
   width: number;
@@ -15,6 +16,7 @@ interface ImageByUriProps {
 }
 
 const ImageByUri = ({
+  id,
   uri,
   alt,
   width,
@@ -65,6 +67,7 @@ const ImageByUri = ({
 
   return (
     <Image
+      id={id}
       src={imageUrl || '/images/Userpic.png'}
       alt={alt}
       width={width}

--- a/apps/web/components/Modal/_Backup.tsx
+++ b/apps/web/components/Modal/_Backup.tsx
@@ -155,6 +155,7 @@ export default function Backup({
             </Typography.H2>
             <Input.Label className="mt-4" value="Password" />
             <Input.Text
+              id='backup-recovery-file-password-input'
               className="h-[70px] mt-1"
               type="password"
               error={errors}
@@ -174,6 +175,7 @@ export default function Backup({
               Back
             </Button.Large>
             <Button.Large
+              id='backup-download-recovery-file-btn'
               icon={<Icon.DownloadSimple />}
               onClick={!loading ? () => handleSubmit() : undefined}
               loading={loading}
@@ -227,6 +229,7 @@ export default function Backup({
                 src="/images/security.png"
               />
               <Button.Large
+                id='backup-recovery-file-btn'
                 icon={<Icon.DownloadSimple />}
                 onClick={() => setFile(true)}
               >

--- a/apps/web/components/Modal/_Logout.tsx
+++ b/apps/web/components/Modal/_Logout.tsx
@@ -45,6 +45,7 @@ export default function Logout({
       </Typography.Body>
       <div className="flex gap-4 mt-8">
         <Button.Large
+          id="logout-modal-sign-out-btn"
           variant="secondary"
           icon={<Icon.SignOut size="16" />}
           onClick={() => router.push(`/logout`)}
@@ -52,6 +53,7 @@ export default function Logout({
           Yes, sign out
         </Button.Large>
         <Modal.SubmitAction
+          id="logout-modal-backup-btn"
           icon={<Icon.Lock size="16" />}
           onClick={() => router.push(`/settings`)}
         >

--- a/apps/web/components/RemindBackup/index.tsx
+++ b/apps/web/components/RemindBackup/index.tsx
@@ -160,6 +160,7 @@ export default function RemindBackup() {
           </Typography.Body>
           <div className="w-full xl:w-[40%] max-w-full flex gap-6">
             <Button.Large
+              id='remind-backup-now-btn'
               onClick={() => setShowModalBackup(true)}
               icon={<Icon.Lock size="16" />}
             >

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "emoji-picker-react": "^4.9.3",
         "get-youtube-id": "^1.0.1",
         "jdenticon": "^3.2.0",
+        "moment": "^2.30.1",
         "next": "^14.2.5",
         "nextjs-toploader": "^1.6.11",
         "react": "18.2.0",
@@ -14419,6 +14420,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "emoji-picker-react": "^4.9.3",
         "get-youtube-id": "^1.0.1",
         "jdenticon": "^3.2.0",
-        "moment": "^2.30.1",
         "next": "^14.2.5",
         "nextjs-toploader": "^1.6.11",
         "react": "18.2.0",
@@ -58,6 +57,7 @@
         "jest": "^29.4.1",
         "jest-environment-jsdom": "^29.4.1",
         "jest-environment-node": "^29.4.1",
+        "moment": "^2.30.1",
         "nx": "17.2.4",
         "postcss": "^8.4.40",
         "prettier": "^2.6.2",
@@ -14426,6 +14426,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
       "engines": {
         "node": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "autoprefixer": "10.4.13",
         "babel-jest": "^29.4.1",
         "cypress": "^13.0.0",
+        "cypress-slow-down": "^1.3.1",
         "eslint": "~8.48.0",
         "eslint-config-next": "13.4.4",
         "eslint-config-prettier": "^9.0.0",
@@ -7798,6 +7799,23 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress-plugin-config": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cypress-plugin-config/-/cypress-plugin-config-1.2.1.tgz",
+      "integrity": "sha512-z+bQ7oyfDKun51HiCVNBOR+g38/nYRJ7zVdCZT2/9UozzE8P4iA1zF/yc85ePZLy5NOj/0atutoUPBBR5SqjSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cypress-slow-down": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cypress-slow-down/-/cypress-slow-down-1.3.1.tgz",
+      "integrity": "sha512-ktlu38FuRn3lUNMGKXrrCLke/pCpRufnqC9Tk7z7u9OblyBZbrdTAHRIzn3IrYe+0ZFc781KHTbq02JxKdi9SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cypress-plugin-config": "^1.0.0"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "autoprefixer": "10.4.13",
     "babel-jest": "^29.4.1",
     "cypress": "^13.0.0",
+    "cypress-slow-down": "^1.3.1",
     "eslint": "~8.48.0",
     "eslint-config-next": "13.4.4",
     "eslint-config-prettier": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "jest": "^29.4.1",
     "jest-environment-jsdom": "^29.4.1",
     "jest-environment-node": "^29.4.1",
+    "moment": "^2.30.1",
     "nx": "17.2.4",
     "postcss": "^8.4.40",
     "prettier": "^2.6.2",


### PR DESCRIPTION
This contains two new workflows that do roughly the same thing: build and run everything needed to execute the Cypress E2E tests. 

One workflow uses a matrix to build and run tests on chrome and firefox asynchronously in isolated jobs.
The other workflow does the same but without matrix, each test run is sequential and both test instances share the same backend instance. This workflow is currently disabled but worth keeping for reference.

Also fixed failing E2E tests and extend recovery backup test to also save file.