### PR TITLE
Feat: save and restore feed filters to homeserver

### DIFF
--- a/apps/web/contexts/_filters.tsx
+++ b/apps/web/contexts/_filters.tsx
@@ -15,7 +15,7 @@ import {
   NotificationPreferences,
 } from './../types';
 
-type FilterContextType = {
+export type FilterContextType = {
   layout: TLayouts;
   setLayout(layout: TLayouts): void;
   sort: TSort;

--- a/apps/web/contexts/_filters.tsx
+++ b/apps/web/contexts/_filters.tsx
@@ -15,7 +15,7 @@ import {
   NotificationPreferences,
 } from './../types';
 
-export type FilterContextType = {
+type FilterContextType = {
   layout: TLayouts;
   setLayout(layout: TLayouts): void;
   sort: TSort;

--- a/apps/web/contexts/_pubky.tsx
+++ b/apps/web/contexts/_pubky.tsx
@@ -13,11 +13,10 @@ import { PostKind, PostView, PubkyAppPost, PubkyAppUser } from '@/types/Post';
 import { generateTimestampId } from 'libs/utils-shared/src/lib/Crypto/generateTimestampId';
 import { UserDetails } from '@/types/User';
 import { generateHashId } from 'libs/utils-shared/src/lib/Crypto/generateHashId';
-import { TStatus } from '@/types';
+import { ICustomFeed, TStatus } from '@/types';
 import JSZip from 'jszip';
 import * as bip39 from 'bip39';
 import { getUserProfile } from '@/services/userService';
-import { FilterContextType } from './_filters';
 
 const HOMESERVER_PUBLIC_KEY = process.env.NEXT_PUBLIC_HOMESERVER;
 
@@ -1131,7 +1130,7 @@ export function PubkyClientWrapper({
   };
 
   const saveFeed = async (
-    filter: FilterContextType,
+    feed: ICustomFeed,
     name: string,
   ): Promise<boolean> => {
     try {
@@ -1141,14 +1140,14 @@ export function PubkyClientWrapper({
       }
 
       const feedData = {
-        filter,
+        feed,
         name,
         created_at: Date.now(),
       };
 
       const feedBody = Buffer.from(JSON.stringify(feedData));
       const feedId = (
-        await generateHashId(JSON.stringify(filter).toLocaleUpperCase())
+        await generateHashId(JSON.stringify(feed).toLowerCase())
       ).toUpperCase();
 
       const feedUrl = `pubky://${pubky}/pub/pubky.app/feeds/${feedId}`;
@@ -1162,7 +1161,7 @@ export function PubkyClientWrapper({
     }
   };
 
-  const loadFeeds = async (): Promise<{ filter: FilterContextType; name: string }[]> => {
+  const loadFeeds = async (): Promise<{ feed: ICustomFeed; name: string }[]> => {
     try {
       // Verify the user is logged in
       const loggedIn = await isLoggedIn();
@@ -1182,7 +1181,7 @@ export function PubkyClientWrapper({
             if (result) {
               const decodedString = new TextDecoder('utf-8').decode(result);
               const parsedData = JSON.parse(decodedString);
-              return { filter: parsedData.filter, name: parsedData.name };
+              return { feed: parsedData.feed, name: parsedData.name };
             }
             return null; // Handle cases where the result might be undefined
           } catch (error) {
@@ -1193,14 +1192,14 @@ export function PubkyClientWrapper({
       );
   
       // Filter out any null entries and assert the result type
-      return feedsData.filter((feed): feed is { filter: FilterContextType; name: string } => feed !== null);
+      return feedsData.filter((feed): feed is { feed: ICustomFeed; name: string } => feed !== null);
     } catch (error) {
       console.error('Error loading feeds:', error);
       return [];
     }
   };
 
-  const deleteFeed = async (filter: FilterContextType): Promise<boolean> => {
+  const deleteFeed = async (feed: ICustomFeed): Promise<boolean> => {
     try {
       // Verify the user is logged in
       const loggedIn = await isLoggedIn();
@@ -1208,8 +1207,8 @@ export function PubkyClientWrapper({
         throw new Error('User is not logged in');
       }
   
-      // Compute the hash ID for the feed based on the filter
-      const feedId = (await generateHashId(JSON.stringify(filter))).toUpperCase();
+      // Compute the hash ID for the feed based on the feed options
+      const feedId = (await generateHashId(JSON.stringify(feed))).toLowerCase();
   
       // Construct the feed URL
       const feedUrl = `pubky://${pubky}/pub/pubky.app/feeds/${feedId}`;

--- a/apps/web/contexts/_pubky.tsx
+++ b/apps/web/contexts/_pubky.tsx
@@ -17,6 +17,7 @@ import { TStatus } from '@/types';
 import JSZip from 'jszip';
 import * as bip39 from 'bip39';
 import { getUserProfile } from '@/services/userService';
+import { FilterContextType } from './_filters';
 
 const HOMESERVER_PUBLIC_KEY = process.env.NEXT_PUBLIC_HOMESERVER;
 
@@ -1147,7 +1148,7 @@ export function PubkyClientWrapper({
 
       const feedBody = Buffer.from(JSON.stringify(feedData));
       const feedId = (
-        await generateHashId(JSON.stringify(filter))
+        await generateHashId(JSON.stringify(filter).toLocaleUpperCase())
       ).toUpperCase();
 
       const feedUrl = `pubky://${pubky}/pub/pubky.app/feeds/${feedId}`;
@@ -1196,6 +1197,30 @@ export function PubkyClientWrapper({
     } catch (error) {
       console.error('Error loading feeds:', error);
       return [];
+    }
+  };
+
+  const deleteFeed = async (filter: FilterContextType): Promise<boolean> => {
+    try {
+      // Verify the user is logged in
+      const loggedIn = await isLoggedIn();
+      if (!loggedIn) {
+        throw new Error('User is not logged in');
+      }
+  
+      // Compute the hash ID for the feed based on the filter
+      const feedId = (await generateHashId(JSON.stringify(filter))).toUpperCase();
+  
+      // Construct the feed URL
+      const feedUrl = `pubky://${pubky}/pub/pubky.app/feeds/${feedId}`;
+  
+      // Delete the feed from the homeserver
+      await client.delete(feedUrl);
+  
+      return true;
+    } catch (error) {
+      console.error('Error deleting feed:', error);
+      return false;
     }
   };
 

--- a/apps/web/contexts/_pubky.tsx
+++ b/apps/web/contexts/_pubky.tsx
@@ -179,6 +179,13 @@ export function PubkyClientWrapper({
     return true;
   };
 
+  const ensureLoggedIn = async (): Promise<void> => {
+    const loggedIn = await isLoggedIn();
+    if (!loggedIn) {
+      throw new Error('User is not logged in');
+    }
+  };
+  
   const getRecoveryFile = async (password: string): Promise<any | null> => {
     try {
       const base64Seed = Utils.storage.get('seed');
@@ -365,11 +372,7 @@ export function PubkyClientWrapper({
     userProfile: PubkyAppUser
   ): Promise<any | false> => {
     try {
-      const loggedIn = isLoggedIn();
-
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       if (userProfile.image instanceof File) {
         const file = userProfile.image;
@@ -466,10 +469,7 @@ export function PubkyClientWrapper({
     files?: File[]
   ): Promise<{ uri: string; details: PubkyAppPost } | false> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       // Generate a timestamp ID for the post
       const postId = generateTimestampId().toUpperCase();
@@ -545,10 +545,7 @@ export function PubkyClientWrapper({
     files?: File[]
   ): Promise<{ uri: string; details: PubkyAppPost } | false> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       // Generate a timestamp ID for the article
       const articleId = generateTimestampId().toUpperCase();
@@ -622,10 +619,7 @@ export function PubkyClientWrapper({
 
   const editPost = async (post: PostView, postContent: string) => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       const editPost: PubkyAppPost = {
         content: postContent,
@@ -652,10 +646,7 @@ export function PubkyClientWrapper({
 
   const deleteAccount = async () => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       const profileUrl = `pubky://${pubky}/pub/pubky.app/profile.json`;
       const lists = await client.list(profileUrl);
@@ -675,10 +666,7 @@ export function PubkyClientWrapper({
 
   const downloadData = async () => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       const profileUrl = `pubky://${pubky}/pub/pubky.app/profile.json`;
       const lists = await client.list(profileUrl);
@@ -738,10 +726,7 @@ export function PubkyClientWrapper({
 
   const getTimestampNotification = async () => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       const lastReadUrl = `pubky://${pubky}/pub/pubky.app/last_read`;
       const lastRead = await client.get(lastReadUrl);
@@ -763,10 +748,7 @@ export function PubkyClientWrapper({
 
   const putTimestampNotification = async (timestamp: number) => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       const body = { timestamp: timestamp };
       const lastReadBody = Buffer.from(JSON.stringify(body));
@@ -783,10 +765,7 @@ export function PubkyClientWrapper({
 
   const deletePost = async (postId: string): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       // Post URL
       const postUrl = `pubky://${pubky}/pub/pubky.app/posts/${postId}`;
@@ -809,10 +788,7 @@ export function PubkyClientWrapper({
     files?: File[]
   ): Promise<string | false> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       // Generate a timestamp ID for the repost
       const repostId = generateTimestampId().toUpperCase();
@@ -891,10 +867,8 @@ export function PubkyClientWrapper({
     files?: File[]
   ): Promise<string | false> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
+
       const replyId = generateTimestampId().toUpperCase();
 
       const replyPost: PubkyAppPost = {
@@ -950,10 +924,7 @@ export function PubkyClientWrapper({
 
   const follow = async (user_id: string): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in or pubky is not defined');
-      }
+      await ensureLoggedIn();
 
       const followData = {
         created_at: Date.now(),
@@ -973,10 +944,7 @@ export function PubkyClientWrapper({
 
   const unfollow = async (user_id: string): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in or pubky is not defined');
-      }
+      await ensureLoggedIn();
 
       const followUrl = `pubky://${pubky}/pub/pubky.app/follows/${user_id}`;
 
@@ -991,10 +959,7 @@ export function PubkyClientWrapper({
 
   const deleteFile = async (file_uri: string): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in or pubky is not defined');
-      }
+      await ensureLoggedIn();
 
       await client.delete(file_uri);
 
@@ -1007,10 +972,7 @@ export function PubkyClientWrapper({
 
   const mute = async (user_id: string): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in or pubky is not defined');
-      }
+      await ensureLoggedIn();
 
       const muteData = {
         created_at: Date.now(),
@@ -1030,10 +992,7 @@ export function PubkyClientWrapper({
 
   const unmute = async (user_id: string): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in or pubky is not defined');
-      }
+      await ensureLoggedIn();
 
       const muteUrl = `pubky://${pubky}/pub/pubky.app/mutes/${user_id}`;
 
@@ -1051,10 +1010,7 @@ export function PubkyClientWrapper({
     authorId: string
   ): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in or pubky is not defined');
-      }
+      await ensureLoggedIn();
 
       const bookmarkData = {
         uri: `pubky://${authorId}/pub/pubky.app/posts/${postId}`,
@@ -1076,10 +1032,7 @@ export function PubkyClientWrapper({
 
   const deleteBookmark = async (bookmarkId: string): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in or pubky is not defined');
-      }
+      await ensureLoggedIn();
 
       const bookmarkUrl = `pubky://${pubky}/pub/pubky.app/bookmarks/${bookmarkId}`;
 
@@ -1098,10 +1051,7 @@ export function PubkyClientWrapper({
     tagContent: string
   ): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       if (!tagContent || tagContent.trim() === '') {
         throw new Error('Tag content cannot be empty');
@@ -1134,10 +1084,7 @@ export function PubkyClientWrapper({
     name: string,
   ): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       const feedData = {
         feed,
@@ -1163,11 +1110,7 @@ export function PubkyClientWrapper({
 
   const loadFeeds = async (): Promise<{ feed: ICustomFeed; name: string }[]> => {
     try {
-      // Verify the user is logged in
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
   
       // Define the feeds directory path
       const feedsDirUrl = `pubky://${pubky}/pub/pubky.app/feeds/`;
@@ -1201,11 +1144,7 @@ export function PubkyClientWrapper({
 
   const deleteFeed = async (feed: ICustomFeed): Promise<boolean> => {
     try {
-      // Verify the user is logged in
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
   
       // Compute the hash ID for the feed based on the feed options
       const feedId = (await generateHashId(JSON.stringify(feed))).toLowerCase();
@@ -1229,10 +1168,7 @@ export function PubkyClientWrapper({
     tagLabel: string
   ): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       const uriPost = `pubky://${authorId}/pub/pubky.app/posts/${postId}`;
 
@@ -1255,10 +1191,7 @@ export function PubkyClientWrapper({
     tagContent: string
   ): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       if (!tagContent || tagContent.trim() === '') {
         throw new Error('Tag content cannot be empty');
@@ -1291,10 +1224,7 @@ export function PubkyClientWrapper({
     tagLabel: string
   ): Promise<boolean> => {
     try {
-      const loggedIn = await isLoggedIn();
-      if (!loggedIn) {
-        throw new Error('User is not logged in');
-      }
+      await ensureLoggedIn();
 
       const profileUri = `pubky://${profileId}/pub/pubky.app/profile.json`;
       const tagId = (

--- a/apps/web/contexts/_pubky.tsx
+++ b/apps/web/contexts/_pubky.tsx
@@ -1129,6 +1129,76 @@ export function PubkyClientWrapper({
     }
   };
 
+  const saveFeed = async (
+    filter: FilterContextType,
+    name: string,
+  ): Promise<boolean> => {
+    try {
+      const loggedIn = await isLoggedIn();
+      if (!loggedIn) {
+        throw new Error('User is not logged in');
+      }
+
+      const feedData = {
+        filter,
+        name,
+        created_at: Date.now(),
+      };
+
+      const feedBody = Buffer.from(JSON.stringify(feedData));
+      const feedId = (
+        await generateHashId(JSON.stringify(filter))
+      ).toUpperCase();
+
+      const feedUrl = `pubky://${pubky}/pub/pubky.app/feeds/${feedId}`;
+
+      await client.put(feedUrl, feedBody);
+
+      return true;
+    } catch (error) {
+      console.error('Error creating tag:', error);
+      return false;
+    }
+  };
+
+  const loadFeeds = async (): Promise<{ filter: FilterContextType; name: string }[]> => {
+    try {
+      // Verify the user is logged in
+      const loggedIn = await isLoggedIn();
+      if (!loggedIn) {
+        throw new Error('User is not logged in');
+      }
+  
+      // Define the feeds directory path
+      const feedsDirUrl = `pubky://${pubky}/pub/pubky.app/feeds/`;
+      const feedUris = await client.list(feedsDirUrl);
+  
+      // Fetch each feed data
+      const feedsData = await Promise.all(
+        feedUris.map(async (uri) => {
+          try {
+            const result = await client.get(uri);
+            if (result) {
+              const decodedString = new TextDecoder('utf-8').decode(result);
+              const parsedData = JSON.parse(decodedString);
+              return { filter: parsedData.filter, name: parsedData.name };
+            }
+            return null; // Handle cases where the result might be undefined
+          } catch (error) {
+            console.error(`Error fetching feed from ${uri}:`, error);
+            return null;
+          }
+        })
+      );
+  
+      // Filter out any null entries and assert the result type
+      return feedsData.filter((feed): feed is { filter: FilterContextType; name: string } => feed !== null);
+    } catch (error) {
+      console.error('Error loading feeds:', error);
+      return [];
+    }
+  };
+
   const deleteTag = async (
     authorId: string,
     postId: string,

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -183,6 +183,14 @@ export interface IAuthor {
   profile: IProfile;
 }
 
+export interface ICustomFeed {
+  tags: string[],
+  sort: TSort,
+  reach: TReach,
+  layout: TLayouts,
+  content: TContent,
+}
+
 export interface IPostContent {
   content: string;
   parent?: string;
@@ -235,7 +243,7 @@ export interface IFollowed {
   id: string;
 }
 
-interface IViewer {}
+interface IViewer { }
 
 export interface IUserProfile {
   profile: IProfile;


### PR DESCRIPTION
This PR allows saving the `filters` as new `/pubky.app/feeds` 

1. Use the `saveFeed()` `_pubky` context function to save a feed. 
2. To retrieve all existing feeds use the `loadFeeds()` function.
3. To delete a feed from the homeserver use the `deleteFeed()` function. The passed FilterContextType must exactly match the feed/filter to be deleted.