### PR TITLE
Feat: add stream of author replies, replies count and fix v0.2.0 nexus API

### DIFF
--- a/apps/web/app/profile/[creatorPubky]/page.tsx
+++ b/apps/web/app/profile/[creatorPubky]/page.tsx
@@ -101,7 +101,8 @@ export default function Index({
                 following: profile?.counts?.following ?? 0,
                 friends: profile?.counts?.friends ?? 0,
               }}
-              countPosts={profile?.counts?.posts}
+              countPosts={(profile?.counts?.posts ?? 0) - (profile?.counts?.replies ?? 0)}
+              countReplies={profile?.counts?.replies}
               loading={isLoading}
               creatorPubky={creatorPubky}
               profile={profile}

--- a/apps/web/app/profile/[creatorPubky]/page.tsx
+++ b/apps/web/app/profile/[creatorPubky]/page.tsx
@@ -101,7 +101,9 @@ export default function Index({
                 following: profile?.counts?.following ?? 0,
                 friends: profile?.counts?.friends ?? 0,
               }}
-              countPosts={(profile?.counts?.posts ?? 0) - (profile?.counts?.replies ?? 0)}
+              countPosts={
+                (profile?.counts?.posts ?? 0) - (profile?.counts?.replies ?? 0)
+              }
               countReplies={profile?.counts?.replies}
               loading={isLoading}
               creatorPubky={creatorPubky}

--- a/apps/web/app/profile/components/_ContactsProfile/_Root.tsx
+++ b/apps/web/app/profile/components/_ContactsProfile/_Root.tsx
@@ -10,7 +10,7 @@ export default function Root({ children, ...rest }: RootProps) {
       <div className="z-auto">
         <div
           {...rest}
-          id='profile-list-root'
+          id="profile-list-root"
           className={twMerge(
             `flex-col justify-start gap-4 items-start flex`,
             rest.className

--- a/apps/web/app/profile/components/_FilterTabs.tsx
+++ b/apps/web/app/profile/components/_FilterTabs.tsx
@@ -32,24 +32,30 @@ const tabs = [
   },
   {
     id: 3,
+    key: 'replies',
+    icon: <Icon.FileText size="24" color="white" />,
+    label: 'Replies',
+  },
+  {
+    id: 4,
     key: 'followers',
     icon: <Icon.UsersLeft size="24" color="white" />,
     label: 'Followers',
   },
   {
-    id: 4,
+    id: 5,
     key: 'following',
     icon: <Icon.UsersRight size="24" color="white" />,
     label: 'Following',
   },
   {
-    id: 5,
+    id: 6,
     key: 'friends',
     icon: <Icon.Smiley size="24" color="white" />,
     label: 'Friends',
   },
   {
-    id: 6,
+    id: 7,
     key: 'tagged',
     icon: <Icon.Tag size="24" color="white" />,
     label: 'Tagged',
@@ -61,6 +67,7 @@ export default function FilterTabs({
   setActiveTab,
   creatorPubky,
   countPosts,
+  countReplies,
   countContacts,
   loading,
   profile,
@@ -69,6 +76,7 @@ export default function FilterTabs({
   setActiveTab: React.Dispatch<React.SetStateAction<number>>;
   creatorPubky?: string;
   countPosts: number | undefined;
+  countReplies: number | undefined;
   countContacts: {
     followers: number;
     following: number;
@@ -125,6 +133,8 @@ export default function FilterTabs({
         return profile?.counts?.bookmarks;
       case 'posts':
         return countPosts || 0;
+      case 'replies':
+        return countReplies || 0;
       case 'followers':
         return countContacts.followers || 0;
       case 'following':
@@ -199,22 +209,23 @@ export default function FilterTabs({
               </>
             )}
             {activeTab === 2 && <Profile.Posts creatorPubky={creatorPubky} />}
-            {activeTab === 3 && (
+            {activeTab === 3 && <Profile.Replies creatorPubky={creatorPubky} />}
+            {activeTab === 4 && (
               <ContactsProfile
                 creatorPubky={creatorPubky}
                 contacts="followers"
               />
             )}
-            {activeTab === 4 && (
+            {activeTab === 5 && (
               <ContactsProfile
                 creatorPubky={creatorPubky}
                 contacts="following"
               />
             )}
-            {activeTab === 5 && (
+            {activeTab === 6 && (
               <ContactsProfile creatorPubky={creatorPubky} contacts="friends" />
             )}
-            {activeTab === 6 && (
+            {activeTab === 7 && (
               <TaggedAs loading={loading} creatorPubky={creatorPubky} />
             )}
           </>

--- a/apps/web/app/profile/components/_Replies.tsx
+++ b/apps/web/app/profile/components/_Replies.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useRef, useState, useEffect } from 'react';
+import { Typography } from '@social/ui-shared';
+import { Post, Skeleton } from '@/components';
+import { useRepliesStreamByUser } from '@/hooks/usePost';
+import { usePubkyClientContext } from '@/contexts';
+
+export default function Index({ creatorPubky }: { creatorPubky?: string }) {
+  const { pubky, timelineProfile, setTimelineProfile } =
+    usePubkyClientContext();
+  const [skip, setSkip] = useState(0);
+  const limit = 10;
+  const usePubky = creatorPubky ?? pubky;
+  const { data, isLoading, isError } = useRepliesStreamByUser(
+    usePubky ?? '',
+    pubky,
+    skip,
+    limit
+  );
+
+  useEffect(() => {
+    if (!isLoading && data) {
+      if (skip === 0) {
+        setTimelineProfile(data);
+        return;
+      }
+
+      if (!timelineProfile) return;
+
+      const timelineCopy = [...timelineProfile];
+
+      setTimelineProfile([...timelineCopy, ...data]);
+    }
+  }, [data, isLoading]);
+
+  const fetchMorePosts = () => {
+    if (isError) return;
+    const newSkip = skip + limit;
+    setSkip(newSkip);
+  };
+
+  const loader = useInfiniteScroll(fetchMorePosts, isLoading);
+
+  useEffect(() => {
+    if (skip === 0 && data) {
+      setSkip(0);
+    }
+  }, [usePubky]);
+
+  if (isError) console.error(isError);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {timelineProfile &&
+        timelineProfile.length > 0 &&
+        timelineProfile.map(
+          (post) =>
+            post?.details?.content !== '[DELETED]' && (
+              <Post key={post.details.id} post={post} />
+            )
+        )}
+      {isLoading && <Skeleton.Simple />}
+      {timelineProfile && timelineProfile.length === 0 && !isLoading && (
+        <div className="mt-[100px] col-span-3 flex justify-center items-center gap-6">
+          <Typography.H2 className="font-normal text-opacity-50">
+            No replies yet.
+          </Typography.H2>
+        </div>
+      )}
+      <div ref={loader} />
+    </div>
+  );
+}
+
+function useInfiniteScroll(fetchPosts: () => void, isLoading: boolean) {
+  const loader = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry.isIntersecting && !isLoading) {
+          fetchPosts();
+        }
+      },
+      { threshold: 0 }
+    );
+
+    if (loader.current) {
+      observer.observe(loader.current);
+    }
+
+    return () => observer.disconnect();
+  }, [fetchPosts, isLoading]);
+
+  return loader;
+}

--- a/apps/web/app/profile/components/index.tsx
+++ b/apps/web/app/profile/components/index.tsx
@@ -6,6 +6,7 @@ import FilterTabsMobile from './_FilterTabsMobile';
 import NotificationsProfile from './_NotificationsProfile';
 import Bookmarks from './_Bookmarks';
 import Posts from './_Posts';
+import Replies from './_Replies';
 import Sidebar from './Sidebar';
 
 export const Profile = {
@@ -17,5 +18,6 @@ export const Profile = {
   NotificationsProfile,
   Bookmarks,
   Posts,
+  Replies,
   Sidebar,
 };

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -65,7 +65,9 @@ export default function Index() {
               following: user?.counts?.following ?? 0,
               friends: user?.counts?.friends ?? 0,
             }}
-            countPosts={(user?.counts?.posts ?? 0) - (user?.counts?.replies ?? 0)}
+            countPosts={
+              (user?.counts?.posts ?? 0) - (user?.counts?.replies ?? 0)
+            }
             countReplies={user?.counts?.replies}
             loading={isLoading}
             profile={user}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -65,7 +65,8 @@ export default function Index() {
               following: user?.counts?.following ?? 0,
               friends: user?.counts?.friends ?? 0,
             }}
-            countPosts={user?.counts?.posts}
+            countPosts={(user?.counts?.posts ?? 0) - (user?.counts?.replies ?? 0)}
+            countReplies={user?.counts?.replies}
             loading={isLoading}
             profile={user}
           />

--- a/apps/web/components/CreateContent/Section/index.tsx
+++ b/apps/web/components/CreateContent/Section/index.tsx
@@ -1,9 +1,9 @@
-import FooterArea from "./_FooterArea";
-import InputArea from "./_InputArea";
-import UserArea from "./_UserArea";
+import FooterArea from './_FooterArea';
+import InputArea from './_InputArea';
+import UserArea from './_UserArea';
 
 export const Section = {
-    FooterArea,
-    InputArea,
-    UserArea,
+  FooterArea,
+  InputArea,
+  UserArea,
 };

--- a/apps/web/components/Modal/_DeletePost.tsx
+++ b/apps/web/components/Modal/_DeletePost.tsx
@@ -48,14 +48,14 @@ export default function DeletePost({
       </Typography.Body>
       <div className="flex gap-4 mt-8">
         <Button.Large
-          id='cancel-btn'
+          id="cancel-btn"
           variant="secondary"
           onClick={() => setShowModalDeletePost(false)}
         >
           Cancel
         </Button.Large>
         <Modal.SubmitAction
-          id='delete-post-btn'
+          id="delete-post-btn"
           icon={<Icon.Trash size="16" />}
           onClick={() => {
             handleDeletePost();

--- a/apps/web/components/Modal/_EditPost.tsx
+++ b/apps/web/components/Modal/_EditPost.tsx
@@ -24,7 +24,7 @@ export default function EditPost({
 
   useEffect(() => {
     setContentEditPost(post?.details?.content);
-  }, [post])
+  }, [post]);
 
   const handleSubmit = async (content: string) => {
     if (sendingEditPost) {

--- a/apps/web/components/Modal/_TagCreatePost.tsx
+++ b/apps/web/components/Modal/_TagCreatePost.tsx
@@ -111,7 +111,7 @@ export default function TagCreatePost({
       className="w-full"
     >
       <Modal.CloseAction
-        id='close-btn'
+        id="close-btn"
         onClick={() => {
           setShowModalTag(false);
           setTagsError(false);
@@ -211,7 +211,7 @@ export default function TagCreatePost({
                 action={
                   <div className="flex gap-2">
                     <Button.Action
-                      id='add-btn'
+                      id="add-btn"
                       icon={<Icon.Plus size="18" />}
                       variant="custom"
                       size="medium"
@@ -219,7 +219,7 @@ export default function TagCreatePost({
                       onClick={handleAddTag}
                     />
                     <Button.Action
-                      id='emoji-btn'
+                      id="emoji-btn"
                       variant="custom"
                       icon={<Icon.Smiley size="32" />}
                       size="medium"

--- a/apps/web/contexts/_pubky.tsx
+++ b/apps/web/contexts/_pubky.tsx
@@ -762,7 +762,7 @@ export function PubkyClientWrapper({
       await Promise.all(
         dataList.map(async (dataUrl, index) => {
           const result = await client.get(dataUrl);
-  
+
           if (result === undefined) {
             return;
           }
@@ -778,7 +778,7 @@ export function PubkyClientWrapper({
             // Save as binary if not JSON
             dataFolder.file(fileName, result);
           }
-  
+
           // Update progress
           setProgress(Math.round(((index + 1) / totalFiles) * 100));
         })
@@ -800,10 +800,10 @@ export function PubkyClientWrapper({
       a.download = `${pubky}_${formattedDateTime}_pubky.app.zip`;
       document.body.appendChild(a);
       a.click();
-  
+
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
-  
+
       return true;
     } catch (error) {
       console.error('Error downloading data:', error);

--- a/apps/web/hooks/usePost.ts
+++ b/apps/web/hooks/usePost.ts
@@ -11,6 +11,7 @@ import {
   getPostStreamByReach,
   getPostReplies,
   getBookmarkedPosts,
+  getRepliesStreamByUser,
 } from '../services/postService';
 
 export function usePost(authorId: string, postId: string, viewerId?: string) {
@@ -69,6 +70,19 @@ export function usePostStreamByUser(
   return useQuery({
     queryKey: ['postStreamByUser', userId, viewerId, skip, limit],
     queryFn: () => getPostStreamByUser(userId, viewerId, skip, limit),
+    retry: false,
+  });
+}
+
+export function useRepliesStreamByUser(
+  userId: string,
+  viewerId?: string,
+  skip?: number,
+  limit?: number
+) {
+  return useQuery({
+    queryKey: ['repliesStreamByUser', userId, viewerId, skip, limit],
+    queryFn: () => getRepliesStreamByUser(userId, viewerId, skip, limit),
     retry: false,
   });
 }

--- a/apps/web/services/postService.ts
+++ b/apps/web/services/postService.ts
@@ -114,7 +114,7 @@ export async function getPostStreamByUser(
 
   if (userId) {
     queryParams.append('author_id', userId);
-    queryParams.append('source', "author");
+    queryParams.append('source', 'author');
   }
   if (viewerId) {
     queryParams.append('viewer_id', viewerId);
@@ -143,7 +143,7 @@ export async function getRepliesStreamByUser(
 
   if (userId) {
     queryParams.append('author_id', userId);
-    queryParams.append('source', "author_replies");
+    queryParams.append('source', 'author_replies');
   }
   if (viewerId) {
     queryParams.append('viewer_id', viewerId);

--- a/apps/web/services/postService.ts
+++ b/apps/web/services/postService.ts
@@ -114,6 +114,36 @@ export async function getPostStreamByUser(
 
   if (userId) {
     queryParams.append('author_id', userId);
+    queryParams.append('source', "author");
+  }
+  if (viewerId) {
+    queryParams.append('viewer_id', viewerId);
+  }
+  if (skip !== undefined) {
+    queryParams.append('skip', String(skip));
+  }
+  if (limit !== undefined) {
+    queryParams.append('limit', String(limit));
+  }
+
+  const response = await fetch(`${BASE_URL}/stream/posts?${queryParams}`);
+
+  if (!response.ok) throw new Error('Failed to fetch post stream by user');
+
+  return response.json();
+}
+
+export async function getRepliesStreamByUser(
+  userId: string,
+  viewerId?: string,
+  skip?: number,
+  limit?: number
+): Promise<PostView[]> {
+  const queryParams = new URLSearchParams();
+
+  if (userId) {
+    queryParams.append('author_id', userId);
+    queryParams.append('source', "author_replies");
   }
   if (viewerId) {
     queryParams.append('viewer_id', viewerId);
@@ -162,7 +192,7 @@ export async function getPostReplies(
   const queryParams = new URLSearchParams();
 
   queryParams.append('author_id', authorId);
-  queryParams.append('source', 'replies');
+  queryParams.append('source', 'post_replies');
   queryParams.append('post_id', postId);
 
   if (viewerId) {
@@ -195,6 +225,7 @@ export async function getBookmarkedPosts(
   }
   if (viewerId) {
     queryParams.append('viewer_id', viewerId);
+    queryParams.append('observer_id', viewerId);
   }
   if (skip !== undefined) {
     queryParams.append('skip', String(skip));

--- a/apps/web/services/postService.ts
+++ b/apps/web/services/postService.ts
@@ -78,6 +78,7 @@ export async function getPostStream(
 
   if (viewerId) {
     queryParams.append('viewer_id', viewerId);
+    queryParams.append('observer_id', viewerId);
   }
   if (skip !== undefined) {
     queryParams.append('skip', String(skip));

--- a/apps/web/types/User.ts
+++ b/apps/web/types/User.ts
@@ -6,6 +6,8 @@ export interface UserCounts {
   friends: number;
   posts: number;
   tags: number;
+  replies: number;
+  tagged: number;
   bookmarks: number;
 }
 


### PR DESCRIPTION
Only works with Nexus v0.2.0

- [x] Fix Stream API calls for nexus v0.2.0
- [x] Add a new tab to profile for "Replies" with `counts.replies`.
- [x] Compute correctly number of stream of posts (total posts - replies) 
- [x] Add new functionality to get `author_replies`
- [x] Add author replies stream to profile

I have noticed a bug where new replies are not shown in the stream of replies, but those that have been reindexed are shown. So I believe this functionality works well but Nexus watcher might have a bug on handling new reply posts from homeserver events into sorted set of replies. Edit: can confirm this bug is not real.