### PR TITLE
Fix: validate recovery phrase

### DIFF
--- a/apps/web/contexts/_pubky.tsx
+++ b/apps/web/contexts/_pubky.tsx
@@ -292,13 +292,12 @@ export function PubkyClientWrapper({
 
   const loginWithMnemonic = async (mnemonic: string) => {
     try {
+      if (!bip39.validateMnemonic(mnemonic)) {
+        throw new Error('Invalid recovery phrase');
+      }
       const seedMnemonic = bip39.mnemonicToSeedSync(mnemonic);
       const secretKey = seedMnemonic.slice(0, 32);
       const keypair = Keypair.fromSecretKey(secretKey);
-
-      if (!keypair) {
-        throw new Error('Invalid recovery phrase');
-      }
 
       // Sign up
       await client.signup(keypair, homeserver);


### PR DESCRIPTION
Any random made up word will create a new valid keypair. This PR fixes it.
![image](https://github.com/user-attachments/assets/b8f98d16-d7d0-4ec5-b38a-a39641c0664c)
