### PR TITLE
changed replies icon

### DIFF
--- a/apps/web/app/profile/components/_FilterTabs.tsx
+++ b/apps/web/app/profile/components/_FilterTabs.tsx
@@ -35,7 +35,7 @@ const tabs = [
   {
     id: 3,
     key: 'replies',
-    icon: <Icon.FileText size="24" color="white" />,
+    icon: <Icon.File size="24" color="white" />,
     label: 'Replies',
   },
   {


### PR DESCRIPTION
In mobile for replies I use `Icon.File`, but on desktop `Icon.FileText`, so I fixed it