### PR TITLE
fix: max-length post/tag

### DIFF
--- a/apps/web/components/CreateContent/Section/_FooterArea.tsx
+++ b/apps/web/components/CreateContent/Section/_FooterArea.tsx
@@ -72,9 +72,11 @@ export default function FooterArea({
     const textAfterCursor = content.slice(cursorPosition);
     const newText = textBeforeCursor + emojiObject.emoji + textAfterCursor;
 
-    setContent(newText);
-    setCursorPosition(cursorPosition + emojiObject.emoji.length);
-    setIsValidContent(Utils.isValidContent(newText));
+    if (newText.length <= maxLength) {
+      setContent(newText);
+      setCursorPosition(cursorPosition + emojiObject.emoji.length);
+      setIsValidContent(Utils.isValidContent(newText));
+    }
   };
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/web/components/CreateContent/Section/_InputArea.tsx
+++ b/apps/web/components/CreateContent/Section/_InputArea.tsx
@@ -156,6 +156,7 @@ export default function InputArea({
           autoFocus={autoFocus}
           value={content}
           isError={isError}
+          maxLength={maxLength}
         />
       ) : (
         <Input.CursorArea

--- a/apps/web/components/Modal/_ProfileTag.tsx
+++ b/apps/web/components/Modal/_ProfileTag.tsx
@@ -241,7 +241,7 @@ export default function ProfileTag({
                     theme={Theme.DARK}
                     emojiStyle={EmojiStyle.TWITTER}
                     onEmojiClick={(emojiObject) => {
-                      setTag(tag + emojiObject.emoji);
+                      if (tag.length < 20) setTag(tag + emojiObject.emoji);
                       setShowEmojis(false);
                     }}
                   />

--- a/apps/web/components/Modal/_Tag.tsx
+++ b/apps/web/components/Modal/_Tag.tsx
@@ -246,7 +246,7 @@ export default function Tag({
         setTag('');
         setTagsError(false);
       }}
-      className="w-full md:w-[792px] max-h-[600px] overflow-y-auto"
+      className="w-full md:w-[900px] max-h-[600px] overflow-y-auto"
     >
       <Modal.CloseAction
         id="close-btn"
@@ -270,7 +270,7 @@ export default function Tag({
                     theme={Theme.DARK}
                     emojiStyle={EmojiStyle.TWITTER}
                     onEmojiClick={(emojiObject) => {
-                      setTag(tag + emojiObject.emoji);
+                      if (tag.length < 20) setTag(tag + emojiObject.emoji);
                       setShowEmojis(false);
                     }}
                   />
@@ -391,8 +391,9 @@ export default function Tag({
                                 width={32}
                                 height={32}
                                 key={imageIndex}
-                                className={`w-[32px] h-[32px] rounded-full shadow justify-center items-center flex ${imageIndex > 0 && '-ml-2'
-                                  }`}
+                                className={`w-[32px] h-[32px] rounded-full shadow justify-center items-center flex ${
+                                  imageIndex > 0 && '-ml-2'
+                                }`}
                                 alt={`tag-${imageIndex + 1}`}
                                 uri={String(image)}
                               />
@@ -480,7 +481,8 @@ export default function Tag({
                             <SideCard.User
                               uri={profile?.details?.id.replace('pubky:', '')}
                               uriImage={
-                                profile?.details?.image || '/images/webp/Userpic.webp'
+                                profile?.details?.image ||
+                                '/images/webp/Userpic.webp'
                               }
                               username={
                                 profile?.details?.name &&

--- a/apps/web/components/Modal/_TagCreatePost.tsx
+++ b/apps/web/components/Modal/_TagCreatePost.tsx
@@ -119,7 +119,7 @@ export default function TagCreatePost({
       />
       <div className="w-full items-stretch flex-col inline-flex gap-6 -mt-6">
         <Modal.Header title="Tag" />
-        <Modal.Content className="flex flex-row w-[350px]">
+        <Modal.Content className="flex flex-row md:w-[350px]">
           <div className="w-full flex-col inline-flex">
             {/**  <div>
               <Typography.Label className="text-opacity-30 font-medium">
@@ -194,7 +194,7 @@ export default function TagCreatePost({
                     theme={Theme.DARK}
                     emojiStyle={EmojiStyle.TWITTER}
                     onEmojiClick={(emojiObject) => {
-                      setTag(tag + emojiObject.emoji);
+                      if (tag.length < 20) setTag(tag + emojiObject.emoji);
                       setShowEmojis(false);
                     }}
                   />

--- a/libs/ui-shared/src/lib/Input/_MarkdownEditor.tsx
+++ b/libs/ui-shared/src/lib/Input/_MarkdownEditor.tsx
@@ -6,6 +6,7 @@ interface MarkdownEditorProps {
   autoFocus?: boolean;
   value: string;
   isError?: boolean;
+  maxLength?: number;
 }
 
 export const MarkdownEditorComponent = ({
@@ -14,6 +15,7 @@ export const MarkdownEditorComponent = ({
   placeHolder,
   autoFocus,
   isError,
+  maxLength,
   ...rest
 }: MarkdownEditorProps) => {
   const errorCSS = `text-red-500 text-sm mt-2`;
@@ -30,7 +32,7 @@ export const MarkdownEditorComponent = ({
         autoFocus={autoFocus}
         {...rest}
       />
-      {isError && <div className={errorCSS}>Max length 1000</div>}
+      {isError && <div className={errorCSS}>Max length {maxLength}</div>}
     </div>
   );
 };


### PR DESCRIPTION
Currently you can avoid maxLength if when you reach the max you start adding emojis, both in post tags, profile tags, and createContent.

This PR fixes this bug