### PR TITLE
fix login

### DIFF
--- a/apps/web/contexts/_pubky.tsx
+++ b/apps/web/contexts/_pubky.tsx
@@ -17,7 +17,6 @@ import { generateHashId } from 'libs/utils-shared/src/lib/Crypto/generateHashId'
 import { ICustomFeed, NotificationPreferences, TStatus } from '@/types';
 import JSZip from 'jszip';
 import * as bip39 from 'bip39';
-import { getUserProfile } from '@/services/userService';
 
 const HOMESERVER_PUBLIC_KEY = process.env.NEXT_PUBLIC_HOMESERVER;
 const TESTNET = process.env.NEXT_PUBLIC_TESTNET?.toLocaleLowerCase() === 'true';
@@ -248,10 +247,6 @@ export function PubkyClientWrapper({
     try {
       // Save pubky state
       const pk = publickey;
-      const user = await getUserProfile(pk, pk);
-      if (user?.details?.name === '[DELETED]') {
-        throw new Error('This account has been deleted');
-      }
 
       Utils.storage.set('pubky_public_key', pk);
       setPubky(pk);
@@ -283,10 +278,6 @@ export function PubkyClientWrapper({
 
       // Save pubky state
       const pk = session.pubky().z32();
-      const user = await getUserProfile(pk, pk);
-      if (user?.details?.name === '[DELETED]') {
-        throw new Error('This account has been deleted');
-      }
 
       Utils.storage.set('pubky_public_key', pk);
       setPubky(pk);
@@ -319,10 +310,6 @@ export function PubkyClientWrapper({
 
       // Save pubky state
       const pk = session.pubky().z32();
-      const user = await getUserProfile(pk, pk);
-      if (user?.details?.name === '[DELETED]') {
-        throw new Error('This account has been deleted');
-      }
 
       Utils.storage.set('pubky_public_key', pk);
       setPubky(pk);


### PR DESCRIPTION
Removed that code because it was useless, there is no difference between a deleted account and an account that never existed

These changes also solve another problem, if I try to log in with 12 old words or recovery file + dated password, if my account exists in the homeserver, but there is no data inside, it will still let me log in but ask me to enter some info to my empty account