### PR TITLE
fix search tags

### DIFF
--- a/apps/web/app/search/components/_Timeline.tsx
+++ b/apps/web/app/search/components/_Timeline.tsx
@@ -78,7 +78,7 @@ const useTimelinePosts = (pubky, skip, limit, reach, sort, searchTags) => {
           { ...timeline }
         );
         setTimeline(newPosts);
-      } else {
+      } else if (searchTags?.length === 0) {
         setTimeline({});
       }
     }


### PR DESCRIPTION
Currently the tag search does not work because timeline is undefined

The problem is certainly linked to the use of useEffect, timeline is triggered like 7 times at each reload

To limit the problem, this PR improves the situation, but does not fix it completely

If I insert two tags, one that exists and one that does not exist and I remove the tag that exists, even if the tag that does not exist is not linked to posts, I will continue to see the previous timeline