### PR TITLE
fix qrLogin

### DIFF
--- a/apps/web/app/onboarding/sign-in/Card/_Join.tsx
+++ b/apps/web/app/onboarding/sign-in/Card/_Join.tsx
@@ -44,9 +44,18 @@ export default function Join() {
           }
         }
       } catch (error: unknown | { message: string }) {
-        const errorMessage = error === 'aead::Error' ? 'Failed to login.' : '';
-        setLoginError(String(errorMessage));
-        if (!errorMessage) handleGenerateAuthUrl();
+        try {
+          const errorMessage =
+            error === 'aead::Error' ? 'Failed to login.' : null;
+
+          if (errorMessage) {
+            setLoginError(errorMessage);
+          } else {
+            handleGenerateAuthUrl();
+          }
+        } catch (error) {
+          console.error('Unexpected error occurred:', error);
+        }
       }
     }
   };

--- a/apps/web/app/onboarding/sign-in/Card/_Join.tsx
+++ b/apps/web/app/onboarding/sign-in/Card/_Join.tsx
@@ -46,7 +46,7 @@ export default function Join() {
       } catch (error: unknown | { message: string }) {
         const errorMessage = error === 'aead::Error' ? 'Failed to login.' : '';
         setLoginError(String(errorMessage));
-        // handleGenerateAuthUrl();
+        if (!errorMessage) handleGenerateAuthUrl();
       }
     }
   };

--- a/apps/web/app/onboarding/sign-in/Card/_Join.tsx
+++ b/apps/web/app/onboarding/sign-in/Card/_Join.tsx
@@ -50,7 +50,6 @@ export default function Join() {
 
           if (errorMessage) {
             setLoginError(errorMessage);
-          } else {
             handleGenerateAuthUrl();
           }
         } catch (error) {

--- a/apps/web/app/sign-in/Card/_SignIn.tsx
+++ b/apps/web/app/sign-in/Card/_SignIn.tsx
@@ -46,7 +46,7 @@ export default function SignIn() {
       } catch (error: unknown | { message: string }) {
         const errorMessage = error === 'aead::Error' ? 'Failed to login.' : '';
         setLoginError(String(errorMessage));
-        // handleGenerateAuthUrl();
+        if (!errorMessage) handleGenerateAuthUrl();
       }
     }
   };

--- a/apps/web/app/sign-in/Card/_SignIn.tsx
+++ b/apps/web/app/sign-in/Card/_SignIn.tsx
@@ -44,9 +44,18 @@ export default function SignIn() {
           }
         }
       } catch (error: unknown | { message: string }) {
-        const errorMessage = error === 'aead::Error' ? 'Failed to login.' : '';
-        setLoginError(String(errorMessage));
-        if (!errorMessage) handleGenerateAuthUrl();
+        try {
+          const errorMessage =
+            error === 'aead::Error' ? 'Failed to login.' : null;
+
+          if (errorMessage) {
+            setLoginError(errorMessage);
+          } else {
+            handleGenerateAuthUrl();
+          }
+        } catch (error) {
+          console.error('Unexpected error occurred:', error);
+        }
       }
     }
   };

--- a/apps/web/app/sign-in/Card/_SignIn.tsx
+++ b/apps/web/app/sign-in/Card/_SignIn.tsx
@@ -50,7 +50,6 @@ export default function SignIn() {
 
           if (errorMessage) {
             setLoginError(errorMessage);
-          } else {
             handleGenerateAuthUrl();
           }
         } catch (error) {


### PR DESCRIPTION
Hey Miguel, in another commit I think you commented this line of code, please leave it, it is used to fix https://github.com/pubky/pubky-app/issues/759

I improved it because if for some reason there is a timeout etc, by calling the function I recreate a new qrCode, if instead there is an access problem it means that the qrCode is still valid so I do not regenerate it and show the error message