### PR TITLE
fix notiifcations after logout

### DIFF
--- a/apps/web/app/profile/components/notifications/components/_Notification.tsx
+++ b/apps/web/app/profile/components/notifications/components/_Notification.tsx
@@ -234,20 +234,20 @@ export default function Notification({
                   : notification.body.delete_source === 'bookmark'
                     ? ' a post you bookmarked'
                     : notification.body.delete_source === 'reply_parent'
-                      ? ' a post you replied to'
+                      ? ' a post you replied'
                       : notification.body.delete_source === 'repost_embed'
                         ? ' a post you reposted'
                         : ' a post you tagged')}
             {notification.body.type === notificationType?.post_edited?.type &&
-              (notification.body.delete_source === 'reply'
+              (notification.body.edit_source === 'reply'
                 ? ' a reply of your post'
-                : notification.body.delete_source === 'repost'
+                : notification.body.edit_source === 'repost'
                   ? 'a repost of your post'
-                  : notification.body.delete_source === 'bookmark'
+                  : notification.body.edit_source === 'bookmark'
                     ? ' a post you bookmarked'
-                    : notification.body.delete_source === 'reply_parent'
-                      ? ' a post you replied to'
-                      : notification.body.delete_source === 'repost_embed'
+                    : notification.body.edit_source === 'reply_parent'
+                      ? ' a post you replied'
+                      : notification.body.edit_source === 'repost_embed'
                         ? ' a post you reposted'
                         : ' a post you tagged')}
           </Typography.Body>

--- a/apps/web/contexts/_notifications.tsx
+++ b/apps/web/contexts/_notifications.tsx
@@ -32,7 +32,9 @@ export function NotificationsWrapper({ children }: { children: ReactNode }) {
   const limit = 30;
   const [skip, setSkip] = useState(0);
   const [notifications, setNotifications] = useState<NotificationView[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [prevPubky, setPrevPubky] = useState<string | null>(null);
 
   const { data: initNotifications } = useUserNotifications(
     pubky ?? '',
@@ -55,35 +57,32 @@ export function NotificationsWrapper({ children }: { children: ReactNode }) {
   };
 
   const fetchNotifications = async () => {
-    try {
-      if (!pubky || !notificationPreferences) return;
+    if (!pubky || !notificationPreferences || !hasMore) return;
 
+    try {
       setLoading(true);
 
       if (initNotifications) {
         const filteredNotifications = initNotifications.filter(
-          (notification: NotificationView) => {
-            return (
-              notificationPreferences &&
-              notificationPreferences[
-                notification.body.type as keyof typeof notificationPreferences
-              ]
-            );
-          },
+          (notification: NotificationView) =>
+            notificationPreferences[
+              notification.body.type as keyof typeof notificationPreferences
+            ],
         );
 
         updateNotifications(filteredNotifications);
 
         const unreadCount = filteredNotifications.reduce(
-          (count: number, notification: NotificationView) => {
-            if (timestamp && notification.timestamp > timestamp) {
-              return count + 1;
-            }
-            return count;
-          },
+          (count, notification) =>
+            timestamp && notification.timestamp > timestamp ? count + 1 : count,
           0,
         );
+
         setUnReadNotification(unreadCount);
+
+        if (filteredNotifications.length < limit) {
+          setHasMore(false);
+        }
       }
     } catch (err) {
       console.error(err);
@@ -93,26 +92,26 @@ export function NotificationsWrapper({ children }: { children: ReactNode }) {
   };
 
   const loadMoreNotifications = async () => {
-    try {
-      if (!pubky || !notificationPreferences) return;
+    if (!pubky || !notificationPreferences || !hasMore || loading) return;
 
+    try {
       setLoading(true);
 
       if (initNotifications) {
         const filteredNotifications = initNotifications.filter(
-          (notification: NotificationView) => {
-            return (
-              notificationPreferences &&
-              notificationPreferences[
-                notification.body.type as keyof typeof notificationPreferences
-              ]
-            );
-          },
+          (notification: NotificationView) =>
+            notificationPreferences[
+              notification.body.type as keyof typeof notificationPreferences
+            ],
         );
 
         updateNotifications(filteredNotifications);
 
-        setSkip((prev) => prev + limit);
+        if (filteredNotifications.length < limit) {
+          setHasMore(false);
+        } else {
+          setSkip((prev) => prev + limit); 
+        }
       }
     } catch (err) {
       console.error(err);
@@ -122,14 +121,15 @@ export function NotificationsWrapper({ children }: { children: ReactNode }) {
   };
 
   useEffect(() => {
-    if (!pubky) {
+    if (pubky !== prevPubky) {
+      setPrevPubky(pubky ?? '');
       setNotifications([]);
       setUnReadNotification(0);
       setSkip(0);
-      return;
+      setHasMore(true);
     }
 
-    if (notificationPreferences) {
+    if (notificationPreferences && pubky) {
       fetchNotifications();
       const interval = setInterval(fetchNotifications, 60000);
       return () => clearInterval(interval);

--- a/apps/web/contexts/_notifications.tsx
+++ b/apps/web/contexts/_notifications.tsx
@@ -122,12 +122,19 @@ export function NotificationsWrapper({ children }: { children: ReactNode }) {
   };
 
   useEffect(() => {
+    if (!pubky) {
+      setNotifications([]);
+      setUnReadNotification(0);
+      setSkip(0);
+      return;
+    }
+
     if (notificationPreferences) {
       fetchNotifications();
       const interval = setInterval(fetchNotifications, 60000);
       return () => clearInterval(interval);
     }
-  }, [pubky, notificationPreferences, initNotifications]);
+  }, [pubky, notificationPreferences]);
 
   return (
     <NotificationsContext.Provider


### PR DESCRIPTION
If you have a profile with notifications, log out and create a profile via "Explore Pubky" and visit notifications you will be able to see the previous user's notifications

This PR fixes it, also fix edited notifications + loop #809, #823, 