### PR TITLE
fix: prevent undefined start in timeline fetch

### DIFF
--- a/apps/web/app/home/components/_Timeline.tsx
+++ b/apps/web/app/home/components/_Timeline.tsx
@@ -106,7 +106,9 @@ export const Timeline = ({ selectedFeed }: TimelineProps) => {
       const lastPost = data[data.length - 1] as PostView;
       if (!lastPost?.details?.indexed_at) return;
 
-      setStart(lastPost.details.indexed_at - 1);
+      if (start !== undefined) {
+        setStart(lastPost.details.indexed_at - 1);
+      }
 
       setTimeline((prev) => {
         // Filter out muted users and duplicate posts in one pass
@@ -133,7 +135,9 @@ export const Timeline = ({ selectedFeed }: TimelineProps) => {
 
   useEffect(() => {
     clearTimeline();
-    fetchPosts();
+    setTimeout(() => {
+      fetchPosts();
+    }, 0);
   }, [reach, sort, tagsFeed, content, mutedUsers]);
 
   useEffect(() => {


### PR DESCRIPTION
The most important changes focus on improving the handling of the timeline state and the fetching of posts.

Improvements to timeline state handling:

* Added a check to update the `start` state only if it is defined. (`apps/web/app/home/components/_Timeline.tsx`)

Enhancements to post fetching:

* Wrapped the `fetchPosts` call in a `setTimeout` with a delay of 0 milliseconds to ensure it runs asynchronously. (`apps/web/app/home/components/_Timeline.tsx`)

How to test:

Change filter Reach in the timeline and the posts should fetch accordantly.