### PR TITLE
fix: infinity scroll and popularity

### DIFF
--- a/apps/web/app/bookmarks/components/_Timeline.tsx
+++ b/apps/web/app/bookmarks/components/_Timeline.tsx
@@ -21,6 +21,7 @@ export const Timeline = () => {
   const { addAlert } = useAlertContext();
   const [timeline, setTimeline] = useState<PostView[]>([]);
   const [start, setStart] = useState<number | undefined>(undefined);
+  const [skip, setSkip] = useState<number>(0);
   const [fetching, setFetching] = useState<boolean>(false);
   const [fetchAttempts, setFetchAttempts] = useState<number>(0);
   const isMobile = useIsMobile(1280);
@@ -30,9 +31,9 @@ export const Timeline = () => {
     'bookmarks',
     undefined,
     limit,
-    start,
+    sort === 'recent' ? start : undefined,
     undefined,
-    undefined,
+    sort === 'popularity' ? skip : undefined,
     sort,
     undefined,
     content,
@@ -41,28 +42,36 @@ export const Timeline = () => {
   const [isBookmarked, setIsBookmarked] = useState('');
 
   const fetchPosts = async () => {
+    if (fetching || !data) return;
     setFetching(true);
+
     try {
-      if (!data || !Array.isArray(data) || data.length === 0) {
+      if (!Array.isArray(data) || data.length === 0) {
         setFetchAttempts((prev) => prev + 1);
         if (fetchAttempts >= 3) setFetching(false);
         return;
       }
 
       const lastPost = data[data.length - 1] as PostView;
-      if (lastPost.bookmark?.indexed_at) {
-        setStart(lastPost.bookmark?.indexed_at - 1);
-        setTimeline((prev) => {
-          const newPosts = data.filter(
-            (post: PostView) =>
-              !prev.some((p) => p.bookmark?.id === post.bookmark?.id),
-          );
-          return [...prev, ...newPosts];
-        });
+
+      if (sort === 'recent') {
+        if (lastPost.bookmark?.indexed_at) {
+          setStart(lastPost.bookmark.indexed_at - 1);
+        }
+      } else if (sort === 'popularity') {
+        setSkip((prev) => prev + limit);
       }
-      setFetching(false);
+
+      setTimeline((prev) => {
+        const newPosts = data.filter(
+          (post: PostView) =>
+            !prev.some((p) => p.bookmark?.id === post.bookmark?.id),
+        );
+        return [...prev, ...newPosts];
+      });
     } catch (error) {
       console.error(error);
+    } finally {
       setFetching(false);
     }
   };
@@ -71,8 +80,10 @@ export const Timeline = () => {
 
   useEffect(() => {
     setStart(undefined);
+    setSkip(0);
     setTimeline([]);
     setFetchAttempts(0);
+    setFetching(false);
     fetchPosts();
   }, [sort, content]);
 

--- a/apps/web/app/home/components/_Timeline.tsx
+++ b/apps/web/app/home/components/_Timeline.tsx
@@ -130,27 +130,30 @@ export const Timeline = ({ selectedFeed }: TimelineProps) => {
         }
       }
 
-      setTimeline((prev) => {
-        if (isInitialLoad) {
-          setIsInitialLoad(false);
-          return data.filter(
+      // Filter posts before setting timeline
+      const filteredPosts = data.filter(
+        (post) =>
+          post?.details?.author &&
+          !mutedUsers?.includes(post.details.author) &&
+          !deletedPosts.includes(post.details.id),
+      );
+
+      // Set timeline without conditional logic
+      if (isInitialLoad) {
+        setTimeline(filteredPosts);
+        setIsInitialLoad(false);
+      } else {
+        setTimeline((prev) => {
+          const posts = data.filter(
             (post) =>
               post?.details?.author &&
               !mutedUsers?.includes(post.details.author) &&
+              !prev.some((p) => p.details.id === post.details.id) &&
               !deletedPosts.includes(post.details.id),
           );
-        }
-
-        const posts = data.filter(
-          (post) =>
-            post?.details?.author &&
-            !mutedUsers?.includes(post.details.author) &&
-            !prev.some((p) => p.details.id === post.details.id) &&
-            !deletedPosts.includes(post.details.id),
-        );
-
-        return [...prev, ...posts];
-      });
+          return [...prev, ...posts];
+        });
+      }
     } catch (error) {
       console.log('Error fetching posts:', error);
       setFetchAttempts((prev) => prev + 1);

--- a/apps/web/app/hot/components/_RenderPosts.tsx
+++ b/apps/web/app/hot/components/_RenderPosts.tsx
@@ -13,41 +13,59 @@ const RenderPosts = () => {
   const limit = 10;
   const { pubky, searchTags, mutedUsers } = usePubkyClientContext();
   const [timeline, setTimeline] = useState<PostView[]>([]);
-  const [start, setStart] = useState<number | undefined>(undefined);
-  const { reach, layout, sort } = useFilterContext();
+  const [skip, setSkip] = useState<number>(0);
+  const [fetching, setFetching] = useState<boolean>(false);
+  const [fetchAttempts, setFetchAttempts] = useState<number>(0);
+  const { reach, layout } = useFilterContext();
   const isMobile = useIsMobile();
+
   const { data, isLoading } = useStreamPost(
     pubky ?? '',
     'all',
     undefined,
     limit,
-    start,
     undefined,
     undefined,
-    'recent',
+    skip,
+    'popularity',
+    undefined,
+    undefined,
   );
 
   const fetchPosts = async () => {
-    try {
-      if (!data) return;
-      if (!Array.isArray(data)) return;
+    if (fetching || !data) return;
+    setFetching(true);
 
-      const lastPost = data[data.length - 1] as PostView;
-      if (lastPost.details?.indexed_at) {
-        setStart(lastPost.details.indexed_at - 1);
-        setTimeline((prev) => {
-          const newPosts = data.filter((post) => {
-            const isMuted = mutedUsers?.includes(post?.details?.author);
-            const isAlreadyInTimeline = prev.some(
-              (p) => p.details.id === post.details.id,
-            );
-            return !isMuted && !isAlreadyInTimeline;
-          });
-          return [...prev, ...newPosts];
-        });
+    try {
+      if (!Array.isArray(data) || data.length === 0) {
+        setFetchAttempts((prev) => prev + 1);
+        if (fetchAttempts >= 3) {
+          setFetching(false);
+        }
+        return;
       }
+
+      setFetchAttempts(0);
+
+      if (data.length > 0) {
+        setSkip((prev) => prev + limit);
+      }
+
+      setTimeline((prev) => {
+        const newPosts = data.filter((post) => {
+          const isMuted = mutedUsers?.includes(post?.details?.author);
+          const isAlreadyInTimeline = prev.some(
+            (p) => p.details.id === post.details.id,
+          );
+          return !isMuted && !isAlreadyInTimeline;
+        });
+        return [...prev, ...newPosts];
+      });
     } catch (error) {
       console.error(error);
+      setFetchAttempts((prev) => prev + 1);
+    } finally {
+      setFetching(false);
     }
   };
 
@@ -55,18 +73,14 @@ const RenderPosts = () => {
 
   useEffect(() => {
     setTimeline([]);
+    setSkip(0);
+    setFetchAttempts(0);
+    setFetching(false);
 
     return () => {
       setTimeline([]);
     };
-  }, [setTimeline]);
-
-  useEffect(() => {
-    setStart(undefined);
-    setTimeline([]);
-    fetchPosts();
-  }, [searchTags, reach, sort]);
-
+  }, [searchTags, reach]);
 
   return (
     <div className="flex flex-col gap-3" id="hot-posts">
@@ -85,12 +99,12 @@ const RenderPosts = () => {
             </div>
           ),
       )}
-       {isLoading && (
+      {(isLoading || fetching) && (
         <div className="flex flex-col gap-3">
           <Skeleton.Simple />
         </div>
       )}
-         <div ref={loader} />
+      <div ref={loader} />
     </div>
   );
 };

--- a/apps/web/app/hot/components/_RenderPosts.tsx
+++ b/apps/web/app/hot/components/_RenderPosts.tsx
@@ -11,17 +11,17 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 
 const RenderPosts = () => {
   const limit = 10;
-  const { pubky, searchTags, mutedUsers } = usePubkyClientContext();
+  const { pubky, mutedUsers } = usePubkyClientContext();
   const [timeline, setTimeline] = useState<PostView[]>([]);
   const [skip, setSkip] = useState<number>(0);
   const [fetching, setFetching] = useState<boolean>(false);
   const [fetchAttempts, setFetchAttempts] = useState<number>(0);
-  const { reach, layout } = useFilterContext();
+  const { hotTagsReach, timeframe, layout } = useFilterContext();
   const isMobile = useIsMobile();
 
   const { data, isLoading } = useStreamPost(
     pubky ?? '',
-    'all',
+    hotTagsReach,
     undefined,
     limit,
     undefined,
@@ -80,7 +80,7 @@ const RenderPosts = () => {
     return () => {
       setTimeline([]);
     };
-  }, [searchTags, reach]);
+  }, [hotTagsReach, timeframe]);
 
   return (
     <div className="flex flex-col gap-3" id="hot-posts">

--- a/apps/web/app/profile/components/_Posts.tsx
+++ b/apps/web/app/profile/components/_Posts.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Icon } from '@social/ui-shared';
 import { ContentNotFound, Post, Skeleton } from '@/components';
 import { usePubkyClientContext } from '@/contexts';
@@ -10,65 +10,83 @@ import { useStreamPost } from '@/hooks/useStream';
 import Image from 'next/image';
 
 export default function Index({ creatorPubky }: { creatorPubky?: string }) {
-  const { pubky } = usePubkyClientContext();
-
-  const [timeline, setTimeline] = useState<PostView[]>([]);
   const limit = 10;
+  const { pubky } = usePubkyClientContext();
+  const [timeline, setTimeline] = useState<PostView[]>([]);
   const [start, setStart] = useState<number | undefined>(undefined);
   const [fetching, setFetching] = useState<boolean>(false);
   const [fetchAttempts, setFetchAttempts] = useState<number>(0);
 
+  const currentPubky = creatorPubky ?? pubky ?? '';
+
   const { data, isLoading } = useStreamPost(
-    creatorPubky ?? pubky ?? '',
+    currentPubky,
     'author',
-    creatorPubky ?? pubky ?? '',
+    currentPubky,
     limit,
     start,
+    undefined,
+    undefined,
+    'recent',
   );
 
   const fetchPosts = async () => {
+    if (fetching || !data) return;
     setFetching(true);
+
     try {
-      if (!data || !Array.isArray(data) || data.length === 0) {
+      if (!Array.isArray(data) || data.length === 0) {
         setFetchAttempts((prev) => prev + 1);
-        if (fetchAttempts >= 3) setFetching(false);
+        if (fetchAttempts >= 3) {
+          setTimeline([]);
+        }
         return;
       }
 
+      setFetchAttempts(0);
       const lastPost = data[data.length - 1] as PostView;
-      if (lastPost.details?.indexed_at) {
+
+      setTimeline((prev) => {
+        const newPosts = data.filter(
+          (post) =>
+            !prev.some((p) => p.details.id === post.details.id) &&
+            post?.details?.content !== '[DELETED]',
+        );
+        return [...prev, ...newPosts];
+      });
+
+      if (lastPost?.details?.indexed_at) {
         setStart(lastPost.details.indexed_at - 1);
-        setTimeline((prev) => {
-          const newPosts = data.filter(
-            (post: PostView) =>
-              !prev.some((p) => p.details.id === post.details.id),
-          );
-          return [...prev, ...newPosts];
-        });
       }
-      setFetching(false);
     } catch (error) {
       console.error(error);
+      setFetchAttempts((prev) => prev + 1);
+    } finally {
       setFetching(false);
     }
   };
+
+  useEffect(() => {
+    setStart(undefined);
+    setTimeline([]);
+    setFetchAttempts(0);
+    setFetching(false);
+    fetchPosts();
+  }, [currentPubky]);
 
   const loader = useInfiniteScroll(fetchPosts, isLoading);
 
   return (
     <div className="flex flex-col gap-3">
-      {timeline.map(
-        (post) =>
-          post?.details?.content !== '[DELETED]' && (
-            <Post key={`post-${post.details.id}`} post={post} />
-          ),
-      )}
+      {timeline.map((post) => (
+        <Post key={`post-${post.details.id}`} post={post} />
+      ))}
       {(isLoading || fetching) && (
         <div className="flex flex-col gap-3">
           <Skeleton.Simple />
         </div>
       )}
-      <div ref={loader} />
+      <div ref={loader} className="h-20" />
       {!isLoading && !fetching && timeline.length === 0 && (
         <ContentNotFound
           icon={<Icon.Note size="48" color="#C8FF00" />}

--- a/apps/web/app/profile/components/_Replies.tsx
+++ b/apps/web/app/profile/components/_Replies.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Icon } from '@social/ui-shared';
 import { ContentNotFound, Post, Skeleton } from '@/components';
 import { usePubkyClientContext } from '@/contexts';
@@ -23,40 +23,62 @@ export default function Index({ creatorPubky }: { creatorPubky?: string }) {
     </div>
   );
 
+  const currentPubky = creatorPubky ?? pubky ?? '';
+
   const { data, isLoading } = useStreamPost(
-    creatorPubky ?? pubky ?? '',
+    currentPubky,
     'author_replies',
-    creatorPubky ?? pubky ?? '',
+    currentPubky,
     limit,
     start,
+    undefined,
+    undefined,
+    'recent',
   );
 
   const fetchPosts = async () => {
+    if (fetching || !data) return;
     setFetching(true);
+
     try {
-      if (!data || !Array.isArray(data) || data.length === 0) {
+      if (!Array.isArray(data) || data.length === 0) {
         setFetchAttempts((prev) => prev + 1);
-        if (fetchAttempts >= 3) setFetching(false);
+        if (fetchAttempts >= 3) {
+          setTimeline([]);
+        }
         return;
       }
 
+      setFetchAttempts(0);
       const lastPost = data[data.length - 1] as PostView;
-      if (lastPost.details?.indexed_at) {
+
+      setTimeline((prev) => {
+        const newPosts = data.filter(
+          (post) =>
+            !prev.some((p) => p.details.id === post.details.id) &&
+            post?.details?.content !== '[DELETED]',
+        );
+        return [...prev, ...newPosts];
+      });
+
+      if (lastPost?.details?.indexed_at) {
         setStart(lastPost.details.indexed_at - 1);
-        setTimeline((prev) => {
-          const newPosts = data.filter(
-            (post: PostView) =>
-              !prev.some((p) => p.details.id === post.details.id),
-          );
-          return [...prev, ...newPosts];
-        });
       }
-      setFetching(false);
     } catch (error) {
       console.error(error);
+      setFetchAttempts((prev) => prev + 1);
+    } finally {
       setFetching(false);
     }
   };
+
+  useEffect(() => {
+    setStart(undefined);
+    setTimeline([]);
+    setFetchAttempts(0);
+    setFetching(false);
+    fetchPosts();
+  }, [currentPubky]);
 
   const loader = useInfiniteScroll(fetchPosts, isLoading);
 
@@ -87,7 +109,7 @@ export default function Index({ creatorPubky }: { creatorPubky?: string }) {
           <Skeleton.Simple />
         </div>
       )}
-      <div ref={loader} />
+      <div ref={loader} className="h-20" />
       {!isLoading && !fetching && timeline.length === 0 && (
         <ContentNotFound
           icon={<Icon.NoteBlank size="48" color="#C8FF00" />}

--- a/apps/web/app/search/components/_Timeline.tsx
+++ b/apps/web/app/search/components/_Timeline.tsx
@@ -15,6 +15,7 @@ export const Timeline = () => {
   const { pubky, searchTags, mutedUsers } = usePubkyClientContext();
   const [timeline, setTimeline] = useState<PostView[]>([]);
   const [start, setStart] = useState<number | undefined>(undefined);
+  const [skip, setSkip] = useState<number>(0);
   const [fetching, setFetching] = useState<boolean>(false);
   const [fetchAttempts, setFetchAttempts] = useState<number>(0);
   const isMobile = useIsMobile(1280);
@@ -25,40 +26,54 @@ export const Timeline = () => {
     reach,
     'all',
     limit,
-    start,
+    sort === 'recent' ? start : undefined,
     undefined,
-    undefined,
-    undefined,
+    sort === 'popularity' ? skip : undefined,
+    sort,
     searchTags,
     content,
   );
 
   const fetchPosts = async () => {
+    if (fetching || !data) return;
     setFetching(true);
+
     try {
-      if (!data || !Array.isArray(data) || data.length === 0) {
+      if (!Array.isArray(data) || data.length === 0) {
         setFetchAttempts((prev) => prev + 1);
-        if (fetchAttempts >= 3) setFetching(false);
+        if (fetchAttempts >= 3) {
+          setTimeline([]);
+        }
+        setFetching(false);
         return;
       }
 
+      setFetchAttempts(0);
+
       const lastPost = data[data.length - 1] as PostView;
-      if (lastPost.details?.indexed_at) {
-        setStart(lastPost.details.indexed_at - 1);
-        setTimeline((prev) => {
-          const newPosts = data.filter((post) => {
-            const isMuted = mutedUsers?.includes(post?.details?.author);
-            const isAlreadyInTimeline = prev.some(
-              (p) => p.details.id === post.details.id,
-            );
-            return !isMuted && !isAlreadyInTimeline;
-          });
-          return [...prev, ...newPosts];
-        });
+
+      if (sort === 'recent') {
+        if (lastPost.details?.indexed_at) {
+          setStart(lastPost.details.indexed_at - 1);
+        }
+      } else if (sort === 'popularity') {
+        setSkip((prev) => prev + limit);
       }
-      setFetching(false);
+
+      setTimeline((prev) => {
+        const newPosts = data.filter((post) => {
+          const isMuted = mutedUsers?.includes(post?.details?.author);
+          const isAlreadyInTimeline = prev.some(
+            (p) => p.details.id === post.details.id,
+          );
+          return !isMuted && !isAlreadyInTimeline;
+        });
+        return [...prev, ...newPosts];
+      });
     } catch (error) {
       console.error(error);
+      setFetchAttempts((prev) => prev + 1);
+    } finally {
       setFetching(false);
     }
   };
@@ -67,8 +82,10 @@ export const Timeline = () => {
 
   useEffect(() => {
     setStart(undefined);
+    setSkip(0);
     setTimeline([]);
     setFetchAttempts(0);
+    setFetching(false);
     fetchPosts();
   }, [searchTags, reach, sort, content, mutedUsers]);
 

--- a/apps/web/app/settings/_version.tsx
+++ b/apps/web/app/settings/_version.tsx
@@ -44,7 +44,7 @@ export default function Version() {
       </div>
       {showBadge && (
         <span
-          title={`Você está no ambiente ${environmentLabel}`}
+          title={`You are in the ${environmentLabel} environment`}
           className={`px-2 py-1 text-xs font-medium rounded-full cursor-default ${badgeStyle}`}
         >
           {environmentLabel}


### PR DESCRIPTION
- Fixed infinite scroll on the Hot page and updated posts to query based on popularity instead of recency  
- Fixed Hot page posts to respect the reach filter (no longer filtered by timeframe)  
- Fixed infinite scroll on the search page  
- Fixed infinite scroll on the bookmarks page  
- Fixed infinite scroll on profile > posts  
- Fixed infinite scroll on profile > replies  
- Refactor: streamline post filtering logic in timeline component