### PR TITLE
Clean next cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:e2e": "cypress run -P src/cypress",
     "build": "npm --prefix src run build",
     "serve:prod": "npm --prefix src run start",
-    "clean": "rm -rf ./node_modules/ ./dist/",
+    "clean": "rm -rf ./node_modules/ ./src/.next/",
     "format:check": "prettier --check .",
     "format:fix": "prettier --write ."
   },


### PR DESCRIPTION
Include removal of next cache in  `npm run clean` because it can sometimes cause type error on build when modules are removed. We also don't need to clean `dist` anymore since nx was removed.