### PR TITLE
fix loader position visible

### DIFF
--- a/src/app/bookmarks/components/_Timeline.tsx
+++ b/src/app/bookmarks/components/_Timeline.tsx
@@ -150,7 +150,7 @@ export const Timeline = () => {
           <Skeleton.Simple />
         </div>
       )}
-      <div ref={loader} />
+      <div ref={loader} className="fixed bottom-4 left-1/2 -translate-x-1/2" />
       {!isLoading && !fetching && timeline.length === 0 && (
         <ContentNotFound
           icon={<Icon.Bookmarks size="48" color="#C8FF00" />}

--- a/src/app/home/components/_Timeline.tsx
+++ b/src/app/home/components/_Timeline.tsx
@@ -223,7 +223,7 @@ export const Timeline = ({ selectedFeed }: TimelineProps) => {
           <Skeleton.Simple />
         </div>
       )}
-      <div ref={loader} />
+      <div ref={loader} className="fixed bottom-4 left-1/2 -translate-x-1/2" />
       {!isLoading && !fetching && !isSwitchingFilters && timeline.length === 0 && !isInitialLoad && (
         <ContentNotFound
           icon={<Icon.Smiley size="48" color="#C8FF00" />}

--- a/src/app/profile/components/_Posts.tsx
+++ b/src/app/profile/components/_Posts.tsx
@@ -75,7 +75,7 @@ export default function Index({ creatorPubky }: { creatorPubky?: string }) {
           <Skeleton.Simple />
         </div>
       )}
-      <div ref={loader} />
+      <div ref={loader} className="fixed bottom-4 left-1/2 -translate-x-1/2" />
       {!isLoading && !fetching && timeline.length === 0 && (
         <ContentNotFound
           icon={<Icon.Note size="48" color="#C8FF00" />}

--- a/src/app/profile/components/_Replies.tsx
+++ b/src/app/profile/components/_Replies.tsx
@@ -91,7 +91,7 @@ export default function Index({ creatorPubky }: { creatorPubky?: string }) {
           <Skeleton.Simple />
         </div>
       )}
-      <div ref={loader} />
+      <div ref={loader} className="fixed bottom-4 left-1/2 -translate-x-1/2" />
       {!isLoading && !fetching && timeline.length === 0 && (
         <ContentNotFound
           icon={<Icon.NoteBlank size="48" color="#C8FF00" />}

--- a/src/app/search/components/_Timeline.tsx
+++ b/src/app/search/components/_Timeline.tsx
@@ -92,7 +92,7 @@ export const Timeline = () => {
           <Skeleton.Simple />
         </div>
       )}
-      <div ref={loader} />
+      <div ref={loader} className="fixed bottom-4 left-1/2 -translate-x-1/2" />
       {!isLoading && !fetching && timeline.length === 0 && (
         <ContentNotFound
           icon={<Icon.Tag size="48" color="#C8FF00" />}


### PR DESCRIPTION
Probably only on small screens, when there are posts but you scrolled the page you see <ContentNotFound /> which doesn't allow you to see the loader, so I changed the loader css to make it always visible