### PR TITLE
pullDown to refresh page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './global.css';
 import DynamicMeta from '@/components/DynamicMeta';
+import PullDownRefresh from '@/components/PullDownRefresh';
 
 import {
   AlertWrapper,
@@ -18,6 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <DynamicMeta />
       </head>
       <body className="overflow-x-hidden max-w-full">
+        <PullDownRefresh />
         <PubkyClientWrapper>
           <FilterWrapper>
             <AlertWrapper>

--- a/src/components/PullDownRefresh/index.tsx
+++ b/src/components/PullDownRefresh/index.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const PullDownRefresh = () => {
+  const [startY, setStartY] = useState(0);
+  const [isPulling, setIsPulling] = useState(false);
+
+  useEffect(() => {
+    const handleTouchStart = (e: TouchEvent) => {
+      if (window.scrollY === 0) {
+        setStartY(e.touches[0].pageY);
+        setIsPulling(true);
+      }
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!isPulling) return;
+      const currentY = e.touches[0].pageY;
+      if (currentY - startY > 100) {
+        window.location.reload();
+        setIsPulling(false);
+      }
+    };
+
+    const handleTouchEnd = () => setIsPulling(false);
+
+    document.addEventListener('touchstart', handleTouchStart);
+    document.addEventListener('touchmove', handleTouchMove);
+    document.addEventListener('touchend', handleTouchEnd);
+
+    return () => {
+      document.removeEventListener('touchstart', handleTouchStart);
+      document.removeEventListener('touchmove', handleTouchMove);
+      document.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [startY, isPulling]);
+
+  return null;
+};
+
+export default PullDownRefresh;


### PR DESCRIPTION
> _On iOS, Progressive Web Apps (PWAs) do not support pull-to-refresh when running as standalone apps (i.e., installed and opened from the home screen). This is because Safari only handles pull-to-refresh behavior when the app is opened in the browser, not as a standalone app_

We can make it work so that if we detect a scroll down we refresh the page, but this could introduces other bugs

.