### PR TITLE
bug: unexpect session expired

### DIFF
--- a/src/contexts/_pubky.tsx
+++ b/src/contexts/_pubky.tsx
@@ -267,10 +267,12 @@ export function PubkyClientWrapper({ children }: { children: React.ReactNode }) 
   };
 
   const isLoggedIn = async () => {
-    if (!pubky) {
+    // TODO: Temporary fix — this should eventually be replaced with middleware
+    // More info in
+    if (!pubky && !Utils.storage.get('pubky_public_key')) {
+      console.log('Removing pubky context and localStorage...')
       Utils.storage.remove('pubky_public_key');
       setPubky(undefined);
-
       return false;
     }
     return true;

--- a/src/contexts/_pubky.tsx
+++ b/src/contexts/_pubky.tsx
@@ -268,7 +268,7 @@ export function PubkyClientWrapper({ children }: { children: React.ReactNode }) 
 
   const isLoggedIn = async () => {
     // TODO: Temporary fix — this should eventually be replaced with middleware
-    // More info in
+    // More info in https://github.com/pubky/pubky-app/pull/1235
     if (!pubky && !Utils.storage.get('pubky_public_key')) {
       console.log('Removing pubky context and localStorage...')
       Utils.storage.remove('pubky_public_key');

--- a/src/contexts/_pubky.tsx
+++ b/src/contexts/_pubky.tsx
@@ -270,7 +270,7 @@ export function PubkyClientWrapper({ children }: { children: React.ReactNode }) 
     // TODO: Temporary fix — this should eventually be replaced with middleware
     // More info in https://github.com/pubky/pubky-app/pull/1235
     if (!pubky && !Utils.storage.get('pubky_public_key')) {
-      console.log('Removing pubky context and localStorage...')
+      console.log('Removing pubky context and localStorage...');
       Utils.storage.remove('pubky_public_key');
       setPubky(undefined);
       return false;


### PR DESCRIPTION
The previous condition relied on React context to update `pubky` related values, which could lead to timing issues. `Context` updates are asynchronous and may not be applied immediately. Meanwhile, `localStorage` writes happen synchronously. This leads to inconsistent state.
In our case, while the `pubky` context was still updating, the condition was matched and it was clearing the `localStorage` and the `context`, causing the app to treat the user as logged out

=> Next step: Add a more reliable mechanism — such as *middleware* — to ensure consistency during auth-related operations