### PR TITLE
chore: Clean unnessesary requests

### DIFF
--- a/src/components/ImageByUri/index.tsx
+++ b/src/components/ImageByUri/index.tsx
@@ -33,21 +33,28 @@ const ImageByUri = ({ id, uri, alt, width, height, className, style, loading, on
   };
 
   const fetchAvatar = async (key: string) => {
-    // Check cache first
     const cachedUrl = avatarCache.get(key);
     if (cachedUrl) {
-      setImageUrl(cachedUrl);
+      // The user has not avatar, already proved
+      if (cachedUrl === "no_avatar") {
+        await generatedImage(key)
+      } else {
+        setImageUrl(cachedUrl);
+      }
       return;
-    }
-
-    const urlAvatar = `${BASE_URL}/${key}`;
+    } 
     try {
+      const urlAvatar = `${BASE_URL}/${key}`;
       const response = await fetch(urlAvatar);
       if (response.ok) {
         avatarCache.set(key, urlAvatar);
         setImageUrl(urlAvatar);
       } else {
         await generatedImage(key);
+        if (response.status === 404) {
+          // We can avoid the calls once it is proved, the user does not have avatar
+          avatarCache.set(key, "no_avatar");
+        }
       }
     } catch (error) {
       await generatedImage(key);

--- a/src/components/ImageByUri/index.tsx
+++ b/src/components/ImageByUri/index.tsx
@@ -36,13 +36,13 @@ const ImageByUri = ({ id, uri, alt, width, height, className, style, loading, on
     const cachedUrl = avatarCache.get(key);
     if (cachedUrl) {
       // The user has not avatar, already proved
-      if (cachedUrl === "no_avatar") {
-        await generatedImage(key)
+      if (cachedUrl === 'no_avatar') {
+        await generatedImage(key);
       } else {
         setImageUrl(cachedUrl);
       }
       return;
-    } 
+    }
     try {
       const urlAvatar = `${BASE_URL}/${key}`;
       const response = await fetch(urlAvatar);
@@ -53,7 +53,7 @@ const ImageByUri = ({ id, uri, alt, width, height, className, style, loading, on
         await generatedImage(key);
         if (response.status === 404) {
           // We can avoid the calls once it is proved, the user does not have avatar
-          avatarCache.set(key, "no_avatar");
+          avatarCache.set(key, 'no_avatar');
         }
       }
     } catch (error) {

--- a/src/components/Modal/_TagProfile/components/_Utils.tsx
+++ b/src/components/Modal/_TagProfile/components/_Utils.tsx
@@ -47,10 +47,14 @@ export const useUtilsTag = ({ profileTags, setProfileTags, pubkyUser, user }: Ut
   const [hasMoreTaggers, setHasMoreTaggers] = useState(false);
 
   const { data: moreTags, isLoading } = useTagsUser(user?.details.id ?? '', pubky, skip, limit);
+  
 
-  const { data: moreTaggers, isLoading: isLoadingTaggers } = useUserTagTaggers(
-    user?.details.id ?? '',
-    selectedTag?.label ?? '',
+  const {
+    data: moreTaggers,
+    isLoading: isLoadingTaggers,
+  } = useUserTagTaggers(
+    user?.details.id,
+    selectedTag?.label,
     pubky,
     skipTaggers,
     limitTaggers

--- a/src/components/Modal/_TagProfile/components/_Utils.tsx
+++ b/src/components/Modal/_TagProfile/components/_Utils.tsx
@@ -47,12 +47,8 @@ export const useUtilsTag = ({ profileTags, setProfileTags, pubkyUser, user }: Ut
   const [hasMoreTaggers, setHasMoreTaggers] = useState(false);
 
   const { data: moreTags, isLoading } = useTagsUser(user?.details.id ?? '', pubky, skip, limit);
-  
 
-  const {
-    data: moreTaggers,
-    isLoading: isLoadingTaggers,
-  } = useUserTagTaggers(
+  const { data: moreTaggers, isLoading: isLoadingTaggers } = useUserTagTaggers(
     user?.details.id,
     selectedTag?.label,
     pubky,

--- a/src/components/utils-shared/lib/Helper/userProfileCache.ts
+++ b/src/components/utils-shared/lib/Helper/userProfileCache.ts
@@ -29,7 +29,7 @@ class UserProfileCache {
   }
 
   public set(key: string, value: UserView): void {
-    console.log(value)
+    console.log(value);
     this.cache.set(key, value);
     this.lastFetch.set(key, Date.now());
   }

--- a/src/components/utils-shared/lib/Helper/userProfileCache.ts
+++ b/src/components/utils-shared/lib/Helper/userProfileCache.ts
@@ -29,6 +29,7 @@ class UserProfileCache {
   }
 
   public set(key: string, value: UserView): void {
+    console.log(value)
     this.cache.set(key, value);
     this.lastFetch.set(key, Date.now());
   }

--- a/src/components/utils-shared/lib/Helper/userProfileCache.ts
+++ b/src/components/utils-shared/lib/Helper/userProfileCache.ts
@@ -4,7 +4,7 @@ class UserProfileCache {
   private static instance: UserProfileCache;
   private cache: Map<string, UserView>;
   private lastFetch: Map<string, number>;
-  private readonly CACHE_DURATION = 5 * 60 * 1000; // 5 minutos em milissegundos
+  private readonly CACHE_DURATION = 5 * 60 * 1000; // 5 minutes in miliseconds
 
   private constructor() {
     this.cache = new Map();

--- a/src/components/utils-shared/lib/Helper/userProfileCache.ts
+++ b/src/components/utils-shared/lib/Helper/userProfileCache.ts
@@ -29,7 +29,6 @@ class UserProfileCache {
   }
 
   public set(key: string, value: UserView): void {
-    console.log(value);
     this.cache.set(key, value);
     this.lastFetch.set(key, Date.now());
   }

--- a/src/components/utils-shared/lib/Helper/userRelationshipCache.ts
+++ b/src/components/utils-shared/lib/Helper/userRelationshipCache.ts
@@ -1,0 +1,93 @@
+// TODO: Once we refactor to add middleware to manage the app state,
+// it might be interesting to save, instead of `string[]` in the `xxx` type:
+//
+// type xxx {
+//   // total number of pubkys for that relationship
+//   number: number;
+//   // save some random users to display in the user card,
+//   // for example when hovering over a profile (e.g. in post lists)
+//   random: string[];
+// }
+//
+// type Relationship = {
+//   following: xxx;
+//   followers: xxx;
+//   friends: xxx;
+// }
+type Relationship = {
+  following: string[] | undefined;
+  followers: string[] | undefined;
+  friends: string[] | undefined;
+};
+
+function createDefaultRelationship(): Relationship {
+  return {
+    following: undefined,
+    followers: undefined,
+    friends: undefined
+  };
+}
+
+class UserRelationshipCache {
+  private static instance: UserRelationshipCache;
+  private cache: Map<string, Relationship>;
+  private lastFetch: Map<string, number>;
+  private readonly CACHE_DURATION = 5 * 60 * 1000; // 5 minutes in miliseconds
+
+  private constructor() {
+    this.cache = new Map();
+    this.lastFetch = new Map();
+  }
+
+  public static getInstance(): UserRelationshipCache {
+    if (!UserRelationshipCache.instance) {
+      UserRelationshipCache.instance = new UserRelationshipCache();
+    }
+    return UserRelationshipCache.instance;
+  }
+
+  public get(key: string, relationshipType: string): string[] | undefined {
+    const lastFetchTime = this.lastFetch.get(key);
+    if (lastFetchTime && Date.now() - lastFetchTime > this.CACHE_DURATION) {
+      this.cache.delete(key);
+      this.lastFetch.delete(key);
+      return undefined;
+    }
+    const relationship = this.cache.get(key);
+    return relationship?.[relationshipType];
+  }
+
+  // TODO: relationshipType, should be 'keyof Relationship' type
+  public set(key: string, relationshipType: string, value: string[]): void {
+    let relationship = this.cache.get(key);
+    // Make sure if the relationship for that user exist, if not, create a new entry
+    if (!relationship) {
+      let new_relationship = createDefaultRelationship();
+      this.cache.set(key, new_relationship);
+      this.lastFetch.set(key, Date.now());
+      relationship = new_relationship;
+    }
+    relationship[relationshipType] = value;
+    this.cache.set(key, relationship);
+  }
+
+  public clear(): void {
+    this.cache.clear();
+    this.lastFetch.clear();
+  }
+
+  public count(): number {
+    return this.cache.size;
+  }
+
+  public has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  public delete(key: string): void {
+    this.cache.delete(key);
+    this.lastFetch.delete(key);
+  }
+}
+
+export const userRelationshipCache = UserRelationshipCache.getInstance();

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -12,9 +12,11 @@ import {
 } from '../services/postService';
 
 export function usePost(authorId: string, postId: string, viewerId?: string, maxTags?: number, maxTaggers?: number) {
+  const isEnabled = Boolean(authorId?.trim() && postId?.trim());
   return useQuery({
     queryKey: ['post', authorId, postId, viewerId, maxTags, maxTaggers],
     queryFn: () => getPost(authorId, postId, viewerId, maxTags, maxTaggers),
+    enabled: isEnabled,
     retry: false
   });
 }

--- a/src/hooks/useTag.ts
+++ b/src/hooks/useTag.ts
@@ -50,9 +50,13 @@ export function useTagsPost(
 }
 
 export function useTagsUser(userId: string, viewerId?: string, skip?: number, limit?: number, maxTaggers?: number) {
+  const isEnabled = Boolean(userId?.trim());
+
   return useQuery({
     queryKey: ['tagsUser', userId, viewerId, skip, limit, maxTaggers],
-    queryFn: () => getTagsUser(userId, viewerId, skip, limit, maxTaggers),
-    retry: false
+    queryFn: () => getTagsUser(userId!, viewerId, skip, limit, maxTaggers),
+    // control the execution of the query. userId has to have value
+    enabled: isEnabled,
+    retry: false,
   });
 }

--- a/src/hooks/useTag.ts
+++ b/src/hooks/useTag.ts
@@ -57,6 +57,6 @@ export function useTagsUser(userId: string, viewerId?: string, skip?: number, li
     queryFn: () => getTagsUser(userId!, viewerId, skip, limit, maxTaggers),
     // control the execution of the query. userId has to have value
     enabled: isEnabled,
-    retry: false,
+    retry: false
   });
 }

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -123,9 +123,13 @@ export function usePostTagTaggers(
 }
 
 export function useUserTagTaggers(userId: string, tagName: string, viewerId?: string, skip?: number, limit?: number) {
+  const isEnabled = Boolean(userId?.trim() && tagName?.trim());
+
   return useQuery({
     queryKey: ['userTagTaggers', userId, tagName, viewerId, skip, limit],
-    queryFn: () => getUserTagTaggers(userId, tagName, viewerId, skip, limit),
-    retry: false
+    queryFn: () => getUserTagTaggers(userId!, tagName!, viewerId, skip, limit),
+    // control the execution of the query. userId and tagName has to have value
+    enabled: isEnabled,
+    retry: false,
   });
 }

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -130,6 +130,6 @@ export function useUserTagTaggers(userId: string, tagName: string, viewerId?: st
     queryFn: () => getUserTagTaggers(userId!, tagName!, viewerId, skip, limit),
     // control the execution of the query. userId and tagName has to have value
     enabled: isEnabled,
-    retry: false,
+    retry: false
   });
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -76,9 +76,9 @@ export async function getUserDetails(userId: string): Promise<UserDetails> {
 
 /**
  * Fetches a user's relationship list (followers, following, or friends)
- * 
- * This function first checks the in-memory cache. If the relationship data is cached 
- * and not expired, it returns it immediately. Otherwise, it makes an HTTP request to 
+ *
+ * This function first checks the in-memory cache. If the relationship data is cached
+ * and not expired, it returns it immediately. Otherwise, it makes an HTTP request to
  * fetch the relationship data from the server, caches the result, and then returns it
  *
  * @param userId - The ID of the user whose relationship data is being fetched.
@@ -88,10 +88,15 @@ export async function getUserDetails(userId: string): Promise<UserDetails> {
  * @returns A Promise resolving to an array of user IDs representing the relationship
  * @throws An error if the network request fails or the response is not OK
  */
-async function fetchRelationship(userId: string, relationshipType: string, skip?: number, limit?: number): Promise<string[]> {
+async function fetchRelationship(
+  userId: string,
+  relationshipType: string,
+  skip?: number,
+  limit?: number
+): Promise<string[]> {
   const cached = userRelationshipCache.get(userId, relationshipType);
   if (cached) return cached;
-  
+
   const queryParams = new URLSearchParams();
 
   if (skip !== undefined) {
@@ -104,27 +109,27 @@ async function fetchRelationship(userId: string, relationshipType: string, skip?
   const response = await fetch(`${BASE_URL}/user/${userId}/${relationshipType}?${queryParams}`);
   if (!response.ok) throw new Error('Failed to fetch user followers');
 
-  let user_relationship = await response.json()
+  let user_relationship = await response.json();
 
-   // Store in cache
-   userRelationshipCache.set(userId, relationshipType, user_relationship);
+  // Store in cache
+  userRelationshipCache.set(userId, relationshipType, user_relationship);
 
-   return user_relationship;
+  return user_relationship;
 }
 
 // User followers
 export async function getUserFollowers(userId: string, skip?: number, limit?: number): Promise<string[]> {
-  return await fetchRelationship(userId, "followers", skip, limit);
+  return await fetchRelationship(userId, 'followers', skip, limit);
 }
 
 // User following
 export async function getUserFollowing(userId: string, skip?: number, limit?: number): Promise<string[]> {
-  return await fetchRelationship(userId, "following", skip, limit);
+  return await fetchRelationship(userId, 'following', skip, limit);
 }
 
 // User friends
 export async function getUserFriends(userId: string, skip?: number, limit?: number): Promise<string[]> {
-  return await fetchRelationship(userId, "friends", skip, limit);
+  return await fetchRelationship(userId, 'friends', skip, limit);
 }
 
 // User muted

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,8 +1,20 @@
+import { Utils } from '@/components/utils-shared';
 import { UserView, UserCounts, UserDetails, Relationship, UserTag, Taggers } from '../types/User';
 import { userProfileCache } from '@/components/utils-shared/lib/Helper/userProfileCache';
 
 const NEXT_PUBLIC_NEXUS = process.env.NEXT_PUBLIC_NEXUS;
 const BASE_URL = `${NEXT_PUBLIC_NEXUS}/v0`;
+
+async function fetchUserProfile(userId: string, viewerId: string): Promise<UserView> {
+  const queryParams = new URLSearchParams();
+  if (viewerId?.trim()) queryParams.append('viewer_id', viewerId);
+
+  const response = await fetch(`${BASE_URL}/user/${userId}?${queryParams}`);
+
+  if (!response.ok) throw new Error('Failed to fetch user profile');
+
+  return await response.json();
+}
 
 // User profile
 export async function getUserProfile(userId: string, viewerId: string): Promise<UserView> {
@@ -14,14 +26,7 @@ export async function getUserProfile(userId: string, viewerId: string): Promise<
     return cachedUser;
   }
 
-  const queryParams = new URLSearchParams();
-  if (viewerId) queryParams.append('viewer_id', viewerId);
-
-  const response = await fetch(`${BASE_URL}/user/${userId}?${queryParams}`);
-
-  if (!response.ok) throw new Error('Failed to fetch user profile');
-
-  const userData = await response.json();
+  const userData = await fetchUserProfile(userId, viewerId);
 
   // Store in cache
   userProfileCache.set(userId, userData);
@@ -48,11 +53,21 @@ export async function getUserCounts(userId: string): Promise<UserCounts> {
 // User details
 export async function getUserDetails(userId: string): Promise<UserDetails> {
   if (!userId) throw new Error('User ID is required');
-  const response = await fetch(`${BASE_URL}/user/${userId}/details`);
 
-  if (!response.ok) throw new Error('Failed to fetch user details');
+  // Check cache first
+  const cachedUser = userProfileCache.get(userId);
+  if (cachedUser && cachedUser.details) {
+    return cachedUser.details;
+  }
 
-  return response.json();
+  // Get active user pubky. Mainly to get its relationship against that userId
+  const viewer_id = Utils.storage.get('pubky_public_key');
+
+  const userData = await fetchUserProfile(userId, viewer_id as string);
+  // Store in cache
+  userProfileCache.set(userId, userData);
+
+  return userData.details;
 }
 
 // User followers
@@ -205,6 +220,8 @@ export async function getUserNotifications(
   return fileData;
 }
 
+type TaggerScope = 'post' | 'user';
+
 // Post tags taggers
 export async function getPostTagTaggers(
   userId: string,
@@ -214,20 +231,7 @@ export async function getPostTagTaggers(
   skip?: number,
   limit?: number
 ): Promise<Taggers> {
-  const queryParams = new URLSearchParams();
-
-  if (viewerId) queryParams.append('viewer_id', viewerId);
-  if (skip !== undefined) {
-    queryParams.append('skip', String(skip));
-  }
-  if (limit !== undefined) {
-    queryParams.append('limit', String(limit));
-  }
-  const response = await fetch(`${BASE_URL}/post/${userId}/${postId}/taggers/${tagName}?${queryParams}`);
-
-  if (!response.ok) throw new Error('Failed to fetch post tags taggers');
-
-  return response.json();
+  return fetchTaggers('post', userId, tagName, viewerId, postId, skip, limit);
 }
 
 // User tags taggers
@@ -238,18 +242,34 @@ export async function getUserTagTaggers(
   skip?: number,
   limit?: number
 ): Promise<Taggers> {
+  return fetchTaggers('user', userId, tagName, viewerId, undefined, skip, limit);
+}
+
+async function fetchTaggers(
+  scope: TaggerScope,
+  userId: string,
+  tagName: string,
+  viewerId?: string,
+  postId?: string,
+  skip?: number,
+  limit?: number
+): Promise<Taggers> {
   const queryParams = new URLSearchParams();
 
   if (viewerId) queryParams.append('viewer_id', viewerId);
-  if (skip !== undefined) {
-    queryParams.append('skip', String(skip));
-  }
-  if (limit !== undefined) {
-    queryParams.append('limit', String(limit));
-  }
-  const response = await fetch(`${BASE_URL}/user/${userId}/taggers/${tagName}?${queryParams}`);
+  if (skip !== undefined) queryParams.append('skip', String(skip));
+  if (limit !== undefined) queryParams.append('limit', String(limit));
 
-  if (!response.ok) throw new Error('Failed to fetch user tags taggers');
+  let url = '';
+  if (scope === 'post') {
+    if (!postId) throw new Error('postId is required for post-scoped taggers');
+    url = `${BASE_URL}/post/${userId}/${postId}/taggers/${tagName}`;
+  } else {
+    url = `${BASE_URL}/user/${userId}/taggers/${tagName}`;
+  }
+
+  const response = await fetch(`${url}?${queryParams}`);
+  if (!response.ok) throw new Error(`Failed to fetch ${scope} taggers`);
 
   return response.json();
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,6 +1,7 @@
 import { Utils } from '@/components/utils-shared';
 import { UserView, UserCounts, UserDetails, Relationship, UserTag, Taggers } from '../types/User';
 import { userProfileCache } from '@/components/utils-shared/lib/Helper/userProfileCache';
+import { userRelationshipCache } from '@/components/utils-shared/lib/Helper/userRelationshipCache';
 
 const NEXT_PUBLIC_NEXUS = process.env.NEXT_PUBLIC_NEXUS;
 const BASE_URL = `${NEXT_PUBLIC_NEXUS}/v0`;
@@ -38,6 +39,9 @@ export async function getUserProfile(userId: string, viewerId: string): Promise<
 export function clearUserProfileCache(): void {
   userProfileCache.clear();
 }
+export function clearUserRelationshipCache(): void {
+  userRelationshipCache.clear();
+}
 
 // User counts
 export async function getUserCounts(userId: string): Promise<UserCounts> {
@@ -70,8 +74,24 @@ export async function getUserDetails(userId: string): Promise<UserDetails> {
   return userData.details;
 }
 
-// User followers
-export async function getUserFollowers(userId: string, skip?: number, limit?: number): Promise<string[]> {
+/**
+ * Fetches a user's relationship list (followers, following, or friends)
+ * 
+ * This function first checks the in-memory cache. If the relationship data is cached 
+ * and not expired, it returns it immediately. Otherwise, it makes an HTTP request to 
+ * fetch the relationship data from the server, caches the result, and then returns it
+ *
+ * @param userId - The ID of the user whose relationship data is being fetched.
+ * @param relationshipType - The type of relationship to fetch: 'followers', 'following', or 'friends'
+ * @param skip - Optional number of items to skip (for pagination)
+ * @param limit - Optional limit on the number of results to return
+ * @returns A Promise resolving to an array of user IDs representing the relationship
+ * @throws An error if the network request fails or the response is not OK
+ */
+async function fetchRelationship(userId: string, relationshipType: string, skip?: number, limit?: number): Promise<string[]> {
+  const cached = userRelationshipCache.get(userId, relationshipType);
+  if (cached) return cached;
+  
   const queryParams = new URLSearchParams();
 
   if (skip !== undefined) {
@@ -81,47 +101,30 @@ export async function getUserFollowers(userId: string, skip?: number, limit?: nu
     queryParams.append('limit', String(limit));
   }
 
-  const response = await fetch(`${BASE_URL}/user/${userId}/followers?${queryParams}`);
-
+  const response = await fetch(`${BASE_URL}/user/${userId}/${relationshipType}?${queryParams}`);
   if (!response.ok) throw new Error('Failed to fetch user followers');
 
-  return response.json();
+  let user_relationship = await response.json()
+
+   // Store in cache
+   userRelationshipCache.set(userId, relationshipType, user_relationship);
+
+   return user_relationship;
+}
+
+// User followers
+export async function getUserFollowers(userId: string, skip?: number, limit?: number): Promise<string[]> {
+  return await fetchRelationship(userId, "followers", skip, limit);
 }
 
 // User following
 export async function getUserFollowing(userId: string, skip?: number, limit?: number): Promise<string[]> {
-  const queryParams = new URLSearchParams();
-
-  if (skip !== undefined) {
-    queryParams.append('skip', String(skip));
-  }
-  if (limit !== undefined) {
-    queryParams.append('limit', String(limit));
-  }
-
-  const response = await fetch(`${BASE_URL}/user/${userId}/following?${queryParams}`);
-
-  if (!response.ok) throw new Error('Failed to fetch user following');
-
-  return response.json();
+  return await fetchRelationship(userId, "following", skip, limit);
 }
 
 // User friends
 export async function getUserFriends(userId: string, skip?: number, limit?: number): Promise<string[]> {
-  const queryParams = new URLSearchParams();
-
-  if (skip !== undefined) {
-    queryParams.append('skip', String(skip));
-  }
-  if (limit !== undefined) {
-    queryParams.append('limit', String(limit));
-  }
-
-  const response = await fetch(`${BASE_URL}/user/${userId}/friends?${queryParams}`);
-
-  if (!response.ok) throw new Error('Failed to fetch user friends');
-
-  return response.json();
+  return await fetchRelationship(userId, "friends", skip, limit);
 }
 
 // User muted


### PR DESCRIPTION
- Avoid invalid requests to the tags endpoint; many of them were badly formatted
- Reuse the user profile cache for fetching user details.
- Create a cache for following, follower, and friends data to avoid repeated requests when generating user overviews.
- Fix the avatar requests to reduce the number of 404 errors—some are inevitable, but many can be prevented