### PR TITLE
tests: fix e2e add tag profile

### DIFF
--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -12,7 +12,7 @@ import { slowCypressDown } from 'cypress-slow-down';
 import 'cypress-slow-down/commands';
 import { searchAndFollowProfile, searchForProfile } from '../support/contacts';
 import { clickFollowButton, waitForNotificationDotToDisappear } from '../support/profile';
-import { addProfileTags } from '../support/common';
+import { addProfileTags } from '../support/profile';
 import { checkLatestNotification } from '../support/profile';
 import { HasBackedUp, SkipOnboardingSlides } from '../support/types/enums';
 

--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -12,7 +12,7 @@ import { slowCypressDown } from 'cypress-slow-down';
 import 'cypress-slow-down/commands';
 import { searchAndFollowProfile, searchForProfile } from '../support/contacts';
 import { clickFollowButton, waitForNotificationDotToDisappear } from '../support/profile';
-import { addTagsWithModal } from '../support/common';
+import { addProfileTags } from '../support/common';
 import { checkLatestNotification } from '../support/profile';
 import { HasBackedUp, SkipOnboardingSlides } from '../support/types/enums';
 
@@ -112,7 +112,7 @@ describe('notifications', () => {
     // * profile 2 checks for follow notification? and absence of friend notification
   });
 
-  it('can be notified for tagged post and profile', () => {
+  it.only('can be notified for tagged post and profile', () => {
     // * profile 1 creates a post
     createQuickPost(`I will be notified when this post is tagged! ${Date.now()}`);
 
@@ -124,7 +124,7 @@ describe('notifications', () => {
     // add one tag to profile
     cy.get('#profile-tag-btn').click();
     const profileTag = 'nice';
-    addTagsWithModal([profileTag]);
+    addProfileTags([profileTag]);
 
     // * profile 2 checks for notification for tagged profile
     cy.signOut(HasBackedUp.Yes);

--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -112,7 +112,7 @@ describe('notifications', () => {
     // * profile 2 checks for follow notification? and absence of friend notification
   });
 
-  it.only('can be notified for tagged post and profile', () => {
+  it('can be notified for tagged post and profile', () => {
     // * profile 1 creates a post
     createQuickPost(`I will be notified when this post is tagged! ${Date.now()}`);
 

--- a/cypress/support/common.ts
+++ b/cypress/support/common.ts
@@ -49,3 +49,18 @@ export const addTagsWithModal = (tags: string[]) => {
     cy.get('#close-btn').click();
   });
 };
+
+// add tags to a profile using the profile tagged page
+export const addProfileTags = (tags: string[]) => {
+  // click on the profile tagged tab
+  cy.get('#profile-tab-tagged').click();
+
+  // add the tag
+  for (const tag of tags) {
+    cy.get('#add-tag-input').type(tag);
+    cy.get('#add-tag-btn').should('be.visible').click();
+  }
+
+  // wait for the tags to be added
+  cy.get(`#tag-${tags[0]}`).should('be.visible');
+};

--- a/cypress/support/common.ts
+++ b/cypress/support/common.ts
@@ -49,18 +49,3 @@ export const addTagsWithModal = (tags: string[]) => {
     cy.get('#close-btn').click();
   });
 };
-
-// add tags to a profile using the profile tagged page
-export const addProfileTags = (tags: string[]) => {
-  // click on the profile tagged tab
-  cy.get('#profile-tab-tagged').click();
-
-  // add the tag
-  for (const tag of tags) {
-    cy.get('#add-tag-input').type(tag);
-    cy.get('#add-tag-btn').should('be.visible').click();
-  }
-
-  // wait for the tags to be added
-  cy.get(`#tag-${tags[0]}`).should('be.visible');
-};

--- a/cypress/support/profile.ts
+++ b/cypress/support/profile.ts
@@ -129,3 +129,18 @@ export const checkLatestNotification = (expectedContent: string[], profileToNavi
       });
   }
 };
+
+// add tags to a profile using the profile tagged page
+export const addProfileTags = (tags: string[]) => {
+  // click on the profile tagged tab
+  cy.get('#profile-tab-tagged').click();
+
+  // add the tag
+  for (const tag of tags) {
+    cy.get('#add-tag-input').type(tag);
+    cy.get('#add-tag-btn').should('be.visible').click();
+  }
+
+  // wait for the tags to be added
+  cy.get(`#tag-${tags[0]}`).should('be.visible');
+};

--- a/src/app/profile/components/_TaggedAs.tsx
+++ b/src/app/profile/components/_TaggedAs.tsx
@@ -299,6 +299,7 @@ export default function TaggedAs({ creatorPubky, loading }: TaggedAsProps) {
                       return (
                         <div className="flex gap-2" key={index}>
                           <PostUtil.Tag
+                            id={`tag-${tag?.label}`}
                             clicked={isTagFound}
                             onClick={(event) => {
                               event.stopPropagation();


### PR DESCRIPTION
Fixed `notification.cy.ts` test that was failing due to changes in profile tags.

<img width="732" alt="image" src="https://github.com/user-attachments/assets/321e873e-876e-415b-b29a-1bd737baa988" />
