### PR TITLE
feat: manage connectionLost session

### DIFF
--- a/src/app/home/components/_Timeline.tsx
+++ b/src/app/home/components/_Timeline.tsx
@@ -15,7 +15,8 @@ import { getStreamPosts } from '@/services/streamService';
 import { PostView } from '@/types/Post';
 
 export const Timeline = () => {
-  const { pubky, mutedUsers, newPosts, setNewPosts, timeline, setTimeline, deletedPosts } = usePubkyClientContext();
+  const { pubky, mutedUsers, newPosts, setNewPosts, timeline, setTimeline, deletedPosts, isOnline } =
+    usePubkyClientContext();
   const { reach, layout, sort, content, selectedFeed } = useFilterContext();
 
   const isMobile = useIsMobile(1024);
@@ -182,11 +183,15 @@ export const Timeline = () => {
   // Reset and fetch new data when feed changes
   useEffect(() => {
     initializeTimeline();
-  }, [reach, sort, content, selectedFeed?.tags, layout]);
+  }, [reach, sort, content, selectedFeed?.tags, layout, isOnline]);
 
   useEffect(() => {
     fetchNexusData();
   }, [newPosts]);
+
+  const handleTryAgain = () => {
+    window.location.reload();
+  };
 
   return (
     <div id="timeline" className="flex flex-col gap-3">
@@ -209,25 +214,37 @@ export const Timeline = () => {
       {!isLoading && !finishedLoading && <div ref={loader} />}
       {finishedLoading && timeline.length === 0 && (
         <ContentNotFound
-          icon={<Icon.Smiley size="48" color="#C8FF00" />}
-          title="Welcome to your feed!"
+          icon={isOnline ? <Icon.Smiley size="48" color="#C8FF00" /> : <Icon.Globe size="48" color="#e95164" />}
+          title={isOnline ? 'Welcome to your feed!' : 'No internet connection'}
           description={
-            <>
-              It's a blank slate for now, but not for long.
-              <br />
-              Start to create posts, follow interesting people, or explore tags.
-            </>
+            isOnline ? (
+              <>
+                It's a blank slate for now, but not for long.
+                <br />
+                Start to create posts, follow interesting people, or explore tags.
+              </>
+            ) : (
+              <>It seems you're offline. Please check your internet connection and try again.</>
+            )
           }
         >
           <div className="flex gap-3 z-10 justify-center flex-wrap">
-            <Link href="/hot#active">
-              <Button.Medium icon={<Icon.UserPlus size="16" />} className="whitespace-nowrap">
-                Follow Active Users
+            {isOnline ? (
+              <>
+                <Link href="/hot#active">
+                  <Button.Medium icon={<Icon.UserPlus size="16" />} className="whitespace-nowrap">
+                    Follow Active Users
+                  </Button.Medium>
+                </Link>
+                <Link href="hot">
+                  <Button.Medium icon={<Icon.Tag size="16" />}>Explore Tags</Button.Medium>
+                </Link>
+              </>
+            ) : (
+              <Button.Medium className="cursor-pointer" icon={<Icon.Repost size="16" />} onClick={handleTryAgain}>
+                Try again
               </Button.Medium>
-            </Link>
-            <Link href="hot">
-              <Button.Medium icon={<Icon.Tag size="16" />}>Explore Tags</Button.Medium>
-            </Link>
+            )}
           </div>
           <div className="absolute top-64 z-0">
             <Image alt="not-found-feed" width={434} height={434} src="/images/webp/not-found/feed.webp" />

--- a/src/app/onboarding/sign-in/Card/_Join.tsx
+++ b/src/app/onboarding/sign-in/Card/_Join.tsx
@@ -12,7 +12,7 @@ import { useRouter } from 'next/navigation';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
 export default function Join() {
-  const { generateAuthUrl, loginWithAuthUrl } = usePubkyClientContext();
+  const { generateAuthUrl, loginWithAuthUrl, isOnline } = usePubkyClientContext();
   const isMobile = useIsMobile(640);
   const router = useRouter();
   const { addToast } = useToastContext();
@@ -28,6 +28,17 @@ export default function Join() {
   const canvasRef = useRef(null);
 
   useEffect(() => {
+    if (!isOnline) {
+      setLoginError('Error sending request. Check internet connection.');
+      setAuthUrl('');
+    } else {
+      const abortController = new AbortController();
+      handleGenerateAuthUrl(abortController.signal);
+      return () => abortController.abort();
+    }
+  }, [isOnline]);
+
+  useEffect(() => {
     setAppLink(`pubkyring://${authUrl}`);
   }, [authUrl]);
 
@@ -37,15 +48,6 @@ export default function Join() {
       if (newTab) newTab.location.href = fallbackUrl;
     }, 2000);
   };
-
-  useEffect(() => {
-    const abortController = new AbortController();
-    handleGenerateAuthUrl(abortController.signal);
-
-    return () => {
-      abortController.abort();
-    };
-  }, []);
 
   const handleGenerateAuthUrl = async (signal: AbortSignal) => {
     if (signal.aborted) return;
@@ -72,16 +74,7 @@ export default function Join() {
         router.push('/home');
       }
     } catch (error: unknown) {
-      const networkMessage = 'Error sending request. Check internet connection.';
-      const errorMessage = error === 'error sending request' ? networkMessage : String(error);
-      setLoginError(errorMessage);
-
-      if (errorMessage === networkMessage) {
-        setAuthUrl('');
-      } else {
-        // Retry generating auth URL only for non-network errors
-        handleGenerateAuthUrl(signal);
-      }
+      setLoginError(String(error));
       console.error('Login error:', error);
     }
   };

--- a/src/app/sign-in/Card/_SignIn.tsx
+++ b/src/app/sign-in/Card/_SignIn.tsx
@@ -12,7 +12,7 @@ import { useRouter } from 'next/navigation';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
 export default function SignIn() {
-  const { generateAuthUrl, loginWithAuthUrl } = usePubkyClientContext();
+  const { generateAuthUrl, loginWithAuthUrl, isOnline } = usePubkyClientContext();
   const isMobile = useIsMobile(640);
   const router = useRouter();
   const { addToast } = useToastContext();
@@ -28,6 +28,17 @@ export default function SignIn() {
   const canvasRef = useRef(null);
 
   useEffect(() => {
+    if (!isOnline) {
+      setLoginError('Error sending request. Check internet connection.');
+      setAuthUrl('');
+    } else {
+      const abortController = new AbortController();
+      handleGenerateAuthUrl(abortController.signal);
+      return () => abortController.abort();
+    }
+  }, [isOnline]);
+
+  useEffect(() => {
     setAppLink(`pubkyring://${authUrl}`);
   }, [authUrl]);
 
@@ -37,15 +48,6 @@ export default function SignIn() {
       if (newTab) newTab.location.href = fallbackUrl;
     }, 2000);
   };
-
-  useEffect(() => {
-    const abortController = new AbortController();
-    handleGenerateAuthUrl(abortController.signal);
-
-    return () => {
-      abortController.abort();
-    };
-  }, []);
 
   const handleGenerateAuthUrl = async (signal: AbortSignal) => {
     if (signal.aborted) return;
@@ -72,16 +74,7 @@ export default function SignIn() {
         router.push('/home');
       }
     } catch (error: unknown) {
-      const networkMessage = 'Error sending request. Check internet connection.';
-      const errorMessage = error === 'error sending request' ? networkMessage : String(error);
-      setLoginError(errorMessage);
-
-      if (errorMessage === networkMessage) {
-        setAuthUrl('');
-      } else {
-        // Retry generating auth URL only for non-network errors
-        handleGenerateAuthUrl(signal);
-      }
+      setLoginError(String(error));
       console.error('Login error:', error);
     }
   };

--- a/src/components/BottomSheet/_ConnectionLost.tsx
+++ b/src/components/BottomSheet/_ConnectionLost.tsx
@@ -1,0 +1,17 @@
+import { BottomSheet } from '@social/ui-shared';
+import ContentConnectionLost from '../Modal/_ConnectionLost/_Content';
+
+interface ConnectionLostProps {
+  show: boolean;
+  setShow: React.Dispatch<React.SetStateAction<boolean>>;
+  title?: string;
+  className?: string;
+}
+
+export default function ConnectionLost({ show, setShow, title, className }: ConnectionLostProps) {
+  return (
+    <BottomSheet.Root fixed show={show} setShow={setShow} title={title ?? 'Session expired'} className={className}>
+      <ContentConnectionLost />
+    </BottomSheet.Root>
+  );
+}

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -1,6 +1,7 @@
 import Backup from './_Backup';
 import CheckContent from './_CheckContent';
 import CheckLink from './_CheckLink';
+import ConnectionLost from './_ConnectionLost';
 import Content from './_Content';
 import CreateArticle from './_CreateArticle';
 import CreateFeed from './_CreateFeed';
@@ -33,6 +34,7 @@ export const BottomSheet = {
   Backup,
   CheckContent,
   CheckLink,
+  ConnectionLost,
   Content,
   CreateArticle,
   CreateFeed,

--- a/src/components/CreateQuickPost/index.tsx
+++ b/src/components/CreateQuickPost/index.tsx
@@ -64,14 +64,14 @@ export default function CreateQuickPost({ largeView = false, loadingFeed }: Crea
             </a>
           </>
         );
+        setArrayTags([]);
+        setContentPost('');
+        setIsValidContent(false);
+        setTextArea(false);
+        setSelectedFiles([]);
       } else {
         addAlert('Something wrong. Try again', 'warning');
       }
-      setArrayTags([]);
-      setContentPost('');
-      setIsValidContent(false);
-      setTextArea(false);
-      setSelectedFiles([]);
     } catch (error) {
       console.log(error);
     } finally {

--- a/src/components/Modal/_ConnectionLost/_Content.tsx
+++ b/src/components/Modal/_ConnectionLost/_Content.tsx
@@ -1,0 +1,18 @@
+import { Icon, Modal, Typography } from '@social/ui-shared';
+
+export default function ConnectionLost() {
+  const handleTryAgain = () => {
+    window.location.reload();
+  };
+
+  return (
+    <>
+      <Typography.Body className="text-opacity-60" variant="medium">
+        You may have lost your connection. Please check it and try again.
+      </Typography.Body>
+      <Modal.SubmitAction className="mt-4" icon={<Icon.Repost size="16" />} onClick={handleTryAgain}>
+        Try again
+      </Modal.SubmitAction>
+    </>
+  );
+}

--- a/src/components/Modal/_ConnectionLost/index.tsx
+++ b/src/components/Modal/_ConnectionLost/index.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Modal } from '@social/ui-shared';
+import ContentConnectionLost from './_Content';
+
+interface ConnectionLostProps {
+  showModal: boolean;
+  setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function ConnectionLost({ showModal, setShowModal }: ConnectionLostProps) {
+  return (
+    <Modal.Root
+      show={showModal}
+      fixed
+      closeModal={() => setShowModal(false)}
+      className="max-w-[1200px] md:min-w-[588px] max-h-[90vh] overflow-y-auto scrollbar-thin scrollbar-webkit"
+    >
+      <div className="mb-4">
+        <Modal.Header title="Connection lost" />
+      </div>
+      <ContentConnectionLost />
+    </Modal.Root>
+  );
+}

--- a/src/components/Modal/_CreateArticle/_Content.tsx
+++ b/src/components/Modal/_CreateArticle/_Content.tsx
@@ -72,14 +72,14 @@ export default function ContentCreateArticle({
             </a>
           </>
         );
+        setArrayTags([]);
+        setContentArticle('');
+        setShowModalPost && setShowModalPost(false);
+        setShowModalArticle(false);
+        setSelectedFile([]);
       } else {
         addAlert('Something wrong. Try again', 'warning');
       }
-      setArrayTags([]);
-      setContentArticle('');
-      setShowModalPost && setShowModalPost(false);
-      setShowModalArticle(false);
-      setSelectedFile([]);
     } catch (error) {
       console.log(error);
     } finally {

--- a/src/components/Modal/_CreatePost/_Content.tsx
+++ b/src/components/Modal/_CreatePost/_Content.tsx
@@ -67,13 +67,13 @@ export default function ContentCreatePost({ setShowModalPost, setHasContent, cla
             </a>
           </>
         );
+        setArrayTags([]);
+        setContentPost('');
+        setShowModalPost(false);
+        setSelectedFiles([]);
       } else {
         addAlert('Something wrong. Try again', 'warning');
       }
-      setArrayTags([]);
-      setContentPost('');
-      setShowModalPost(false);
-      setSelectedFiles([]);
     } catch (error) {
       console.log(error);
     } finally {

--- a/src/components/Modal/_CreateReply/_Content.tsx
+++ b/src/components/Modal/_CreateReply/_Content.tsx
@@ -95,13 +95,13 @@ export default function ContentCreateReply({
             </a>
           </>
         );
+        setArrayTags([]);
+        setContentReply('');
+        setShowModalReply(false);
+        setSelectedFiles([]);
       } else {
         addAlert('Something wrong. Try again', 'warning');
       }
-      setArrayTags([]);
-      setContentReply('');
-      setShowModalReply(false);
-      setSelectedFiles([]);
     } catch (error) {
       console.log(error);
     } finally {

--- a/src/components/Modal/_CreateRepost/_Content.tsx
+++ b/src/components/Modal/_CreateRepost/_Content.tsx
@@ -68,13 +68,13 @@ export default function ContentCreateRepost({ setShowModalRepost, post, setHasCo
             </a>
           </>
         );
+        setArrayTags([]);
+        setContentRepost('');
+        setShowModalRepost(false);
+        setSelectedFiles([]);
       } else {
         addAlert('Something wrong. Try again', 'warning');
       }
-      setArrayTags([]);
-      setContentRepost('');
-      setShowModalRepost(false);
-      setSelectedFiles([]);
     } catch (error) {
       console.log(error);
     } finally {
@@ -100,13 +100,13 @@ export default function ContentCreateRepost({ setShowModalRepost, post, setHasCo
             </a>
           </>
         );
+        setArrayTags([]);
+        setContentRepost('');
+        setShowModalRepost(false);
+        setSelectedFiles([]);
       } else {
         addAlert('Something wrong. Try again', 'warning');
       }
-      setArrayTags([]);
-      setContentRepost('');
-      setShowModalRepost(false);
-      setSelectedFiles([]);
     } catch (error) {
       console.log(error);
     } finally {

--- a/src/components/Modal/_EditPost/_Content.tsx
+++ b/src/components/Modal/_EditPost/_Content.tsx
@@ -44,16 +44,15 @@ export default function ContentEditPost({ setShowModalEditPost, post, setShowMen
             </a>
           </>
         );
+        setSendingEditPost(false);
+        setShowMenu(false);
+        setShowModalEditPost(false);
       } else {
         addAlert('Something wrong. Try again', 'warning');
       }
     } catch (error) {
       console.log(error);
       addAlert('Error editing post', 'warning');
-    } finally {
-      setSendingEditPost(false);
-      setShowMenu(false);
-      setShowModalEditPost(false);
     }
   };
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,6 +1,7 @@
 import Backup from './_Backup';
 import CheckContent from './_CheckContent';
 import CheckLink from './_CheckLink';
+import ConnectionLost from './_ConnectionLost';
 import CreateArticle from './_CreateArticle';
 import CreateFeed from './_CreateFeed';
 import CreatePost from './_CreatePost';
@@ -28,6 +29,7 @@ export const Modal = {
   Backup,
   CheckContent,
   CheckLink,
+  ConnectionLost,
   CreateArticle,
   CreateFeed,
   CreatePost,

--- a/src/components/ProtectedRoutes/index.tsx
+++ b/src/components/ProtectedRoutes/index.tsx
@@ -23,12 +23,13 @@ export default function ProtectedRoutes({ children }: { children: React.ReactNod
     newUser,
     setNewUser,
     isSessionActive,
-    logout
+    logout,
+    isOnline,
+    setIsOnline
   } = usePubkyClientContext();
   const { openModal, closeModal } = useModal();
   const [loading, setLoading] = useState(true);
   const [imagesLoaded, setImagesLoaded] = useState(false);
-  const [isOnline, setIsOnline] = useState(true);
 
   const publicRoutes = [
     '/onboarding',

--- a/src/components/ProtectedRoutes/index.tsx
+++ b/src/components/ProtectedRoutes/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useModal, usePubkyClientContext } from '@/contexts';
+import { useAlertContext, useModal, usePubkyClientContext } from '@/contexts';
 import { useRouter, usePathname } from 'next/navigation';
 import NextTopLoader from 'nextjs-toploader';
 import React, { useEffect, useState } from 'react';
@@ -28,6 +28,7 @@ export default function ProtectedRoutes({ children }: { children: React.ReactNod
     setIsOnline
   } = usePubkyClientContext();
   const { openModal, closeModal } = useModal();
+  const { connectionAlertStatus } = useAlertContext();
   const [loading, setLoading] = useState(true);
   const [imagesLoaded, setImagesLoaded] = useState(false);
 
@@ -221,18 +222,19 @@ export default function ProtectedRoutes({ children }: { children: React.ReactNod
 
   useEffect(() => {
     const handleOnline = () => {
+      // Only show "connection restored" if we were previously offline
+      if (!isOnline) {
+        connectionAlertStatus(true);
+      }
       setIsOnline(true);
-      closeModal('connectionLost');
-      // Refresh the page to reload all data
-      window.location.reload();
     };
 
     const handleOffline = () => {
       setIsOnline(false);
-      openModal('connectionLost');
+      connectionAlertStatus(false);
     };
 
-    // Set initial online status
+    // Set initial online status without showing any alert
     setIsOnline(navigator.onLine);
 
     // Add event listeners
@@ -244,7 +246,7 @@ export default function ProtectedRoutes({ children }: { children: React.ReactNod
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, []);
+  }, [isOnline]); // Add isOnline to dependencies to check previous state
 
   return (
     <>

--- a/src/components/ProtectedRoutes/index.tsx
+++ b/src/components/ProtectedRoutes/index.tsx
@@ -28,6 +28,7 @@ export default function ProtectedRoutes({ children }: { children: React.ReactNod
   const { openModal, closeModal } = useModal();
   const [loading, setLoading] = useState(true);
   const [imagesLoaded, setImagesLoaded] = useState(false);
+  const [isOnline, setIsOnline] = useState(true);
 
   const publicRoutes = [
     '/onboarding',
@@ -131,7 +132,7 @@ export default function ProtectedRoutes({ children }: { children: React.ReactNod
     const sessionActive = await isSessionActive();
 
     if (sessionActive.status) {
-      if (sessionActive.message === 'connection lost') openModal('connectionLost');
+      if (sessionActive.message === 'connection lost' || !isOnline) openModal('connectionLost');
       const hasProfile = await checkProfileUser();
 
       if (!hasProfile) {
@@ -216,6 +217,31 @@ export default function ProtectedRoutes({ children }: { children: React.ReactNod
 
     preloadImages();
   }, [pathname]);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      setIsOnline(true);
+      closeModal('connectionLost');
+    };
+
+    const handleOffline = () => {
+      setIsOnline(false);
+      openModal('connectionLost');
+    };
+
+    // Set initial online status
+    setIsOnline(navigator.onLine);
+
+    // Add event listeners
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    // Cleanup
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
 
   return (
     <>

--- a/src/components/ProtectedRoutes/index.tsx
+++ b/src/components/ProtectedRoutes/index.tsx
@@ -130,7 +130,8 @@ export default function ProtectedRoutes({ children }: { children: React.ReactNod
   const checkAccess = async () => {
     const sessionActive = await isSessionActive();
 
-    if (sessionActive) {
+    if (sessionActive.status) {
+      if (sessionActive.message === 'connection lost') openModal('connectionLost');
       const hasProfile = await checkProfileUser();
 
       if (!hasProfile) {

--- a/src/components/ProtectedRoutes/index.tsx
+++ b/src/components/ProtectedRoutes/index.tsx
@@ -222,6 +222,8 @@ export default function ProtectedRoutes({ children }: { children: React.ReactNod
     const handleOnline = () => {
       setIsOnline(true);
       closeModal('connectionLost');
+      // Refresh the page to reload all data
+      window.location.reload();
     };
 
     const handleOffline = () => {

--- a/src/components/ui-shared/lib/Alert/_Message.tsx
+++ b/src/components/ui-shared/lib/Alert/_Message.tsx
@@ -5,10 +5,11 @@ import { Typography } from '../Typography';
 interface MessageProps extends React.HTMLAttributes<HTMLDivElement> {
   icon?: React.ReactNode;
   children: React.ReactNode;
-  variant?: 'default' | 'warning';
+  variant?: 'default' | 'warning' | 'connection';
+  isOnline?: boolean;
 }
 
-export const Message = ({ icon, children, variant = 'default', ...rest }: MessageProps) => {
+export const Message = ({ icon, children, variant = 'default', isOnline, ...rest }: MessageProps) => {
   const baseCSS = `z-max relative py-2 px-4 rounded-md shadow border w-full`;
 
   let variantCSS = '';
@@ -18,6 +19,17 @@ export const Message = ({ icon, children, variant = 'default', ...rest }: Messag
     case 'warning':
       variantCSS = 'bg-yellow-600 shadow-[0px_50px_100px_0px_rgba(0,0,0,1.00)] backdrop-blur-[50px] border-yellow-500';
       colorTextCSS = 'text-white';
+      break;
+    case 'connection':
+      if (isOnline) {
+        variantCSS =
+          'bg-[#c8ff00] bg-opacity-10 shadow-[0px_50px_100px_0px_rgba(0,0,0,1.00)] backdrop-blur-[50px] border-[#C8FF00]';
+        colorTextCSS = 'text-[#c8ff00]';
+      } else {
+        variantCSS =
+          'bg-[#e95164] bg-opacity-10 shadow-[0px_50px_100px_0px_rgba(0,0,0,1.00)] backdrop-blur-[50px] border-[#e95164]';
+        colorTextCSS = 'text-[#e95164]';
+      }
       break;
     case 'default':
     default:

--- a/src/components/ui-shared/lib/BottomSheet/_Root.tsx
+++ b/src/components/ui-shared/lib/BottomSheet/_Root.tsx
@@ -10,9 +10,18 @@ interface RootBottomSheetProps extends React.HTMLAttributes<HTMLDivElement> {
   title?: string;
   children?: React.ReactNode;
   homeIndicatorCSS?: string;
+  fixed?: boolean;
 }
 
-export default function Root({ show, setShow, title, children, homeIndicatorCSS, ...rest }: RootBottomSheetProps) {
+export default function Root({
+  show,
+  setShow,
+  title,
+  children,
+  homeIndicatorCSS,
+  fixed = false,
+  ...rest
+}: RootBottomSheetProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [animateIn, setAnimateIn] = useState(false);
   const [startY, setStartY] = useState<number | null>(null);
@@ -45,11 +54,12 @@ export default function Root({ show, setShow, title, children, homeIndicatorCSS,
   }, []);
 
   const handleTouchStart = (e: React.TouchEvent) => {
+    if (fixed) return;
     setStartY(e.touches[0].clientY);
   };
 
   const handleTouchMove = (e: TouchEvent) => {
-    if (startY === null) return;
+    if (fixed || startY === null) return;
 
     const currentY = e.touches[0].clientY;
     const diffY = currentY - startY;
@@ -78,7 +88,7 @@ export default function Root({ show, setShow, title, children, homeIndicatorCSS,
       id="bottom-sheet"
       {...rest}
       className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-end"
-      onClick={() => setShow(false)}
+      onClick={fixed ? undefined : () => setShow(false)}
       onTouchStart={handleTouchStart}
     >
       <div
@@ -86,7 +96,7 @@ export default function Root({ show, setShow, title, children, homeIndicatorCSS,
         onClick={(e) => e.stopPropagation()}
       >
         <div
-          onClick={() => setShow(false)}
+          onClick={fixed ? undefined : () => setShow(false)}
           className={twMerge('flex items-center mt-2 mb-4 justify-center cursor-pointer z-50', homeIndicatorCSS)}
         >
           <Icon.HomeIndicator color="gray" />

--- a/src/components/ui-shared/lib/Modal/_Root.tsx
+++ b/src/components/ui-shared/lib/Modal/_Root.tsx
@@ -8,14 +8,18 @@ interface RootModalProps extends React.HTMLAttributes<HTMLDivElement> {
   show: boolean;
   closeModal: () => void;
   children?: React.ReactNode;
+  fixed?: boolean;
 }
 
-const modalStack: (() => void)[] = [];
+const modalStack: { closeModal: () => void; fixed?: boolean }[] = [];
 
 const handleGlobalKeyDown = (event: KeyboardEvent) => {
   if (event.key === 'Escape' && modalStack.length > 0) {
-    const lastCloseModal = modalStack.pop();
-    lastCloseModal?.();
+    const lastModal = modalStack[modalStack.length - 1];
+    if (!lastModal.fixed) {
+      modalStack.pop(); // Remove it first
+      lastModal.closeModal(); // Then call closeModal
+    }
   }
 };
 
@@ -23,26 +27,28 @@ if (typeof window !== 'undefined') {
   window.addEventListener('keydown', handleGlobalKeyDown);
 }
 
-export const Root = ({ show = false, closeModal, children, ...rest }: RootModalProps) => {
+export const Root = ({ show = false, closeModal, children, fixed = false, ...rest }: RootModalProps) => {
   useEffect(() => {
     if (show) {
-      modalStack.push(closeModal);
+      // Add to stack with its fixed status
+      modalStack.push({ closeModal, fixed });
     }
 
     return () => {
-      const index = modalStack.indexOf(closeModal);
+      // Remove from stack when component unmounts or show/closeModal/fixed changes
+      const index = modalStack.findIndex((item) => item.closeModal === closeModal);
       if (index !== -1) {
         modalStack.splice(index, 1);
       }
     };
-  }, [show, closeModal]);
+  }, [show, closeModal, fixed]); // Add fixed to dependency array
 
   if (!show) return null;
 
   return (
     <div className="flex justify-center items-center">
       <div
-        onClick={closeModal}
+        onClick={fixed ? undefined : closeModal}
         className="fixed top-0 left-0 z-50 w-full h-full bg-black bg-opacity-50 flex justify-center items-center"
       >
         <div id="modal-root" onClick={(e) => e.stopPropagation()}>

--- a/src/contexts/_alerts.tsx
+++ b/src/contexts/_alerts.tsx
@@ -65,7 +65,11 @@ export function AlertWrapper({ children }: { children: React.ReactNode }) {
       case 'warning':
         return <Icon.Warning size="20" />;
       case 'connection':
-        return isOnline ? <Icon.CheckCircle size="20" color="#c8ff00" /> : <Icon.LoadingSpin size="20" color='#e95164' />;
+        return isOnline ? (
+          <Icon.CheckCircle size="20" color="#c8ff00" />
+        ) : (
+          <Icon.LoadingSpin size="20" color="#e95164" />
+        );
       case 'default':
       default:
         return <Icon.CheckCircle size="20" color="#c8ff00" />;
@@ -80,12 +84,7 @@ export function AlertWrapper({ children }: { children: React.ReactNode }) {
         className="fixed z-max left-1/2 transform -translate-x-1/2 flex flex-col gap-2"
       >
         {alerts.map(({ id, content, variant = 'default', isOnline }) => (
-          <Alert.Message
-            key={id}
-            icon={iconToShow(variant, isOnline)}
-            variant={variant}
-            isOnline={isOnline}
-          >
+          <Alert.Message key={id} icon={iconToShow(variant, isOnline)} variant={variant} isOnline={isOnline}>
             {content}
           </Alert.Message>
         ))}

--- a/src/contexts/_alerts.tsx
+++ b/src/contexts/_alerts.tsx
@@ -7,15 +7,19 @@ import { createContext, useContext, useState, ReactNode } from 'react';
 type AlertMessage = {
   id: number;
   content: ReactNode;
-  variant?: 'default' | 'warning';
+  variant?: 'default' | 'warning' | 'connection';
+  persistent?: boolean;
+  isOnline?: boolean;
 };
 
 type AlertContextType = {
   addAlert: (content: ReactNode, variant?: 'default' | 'warning') => void;
+  connectionAlertStatus: (isOnline: boolean) => void;
 };
 
 const AlertContext = createContext<AlertContextType>({
-  addAlert: () => {}
+  addAlert: () => {},
+  connectionAlertStatus: () => {}
 });
 
 export function AlertWrapper({ children }: { children: React.ReactNode }) {
@@ -31,10 +35,37 @@ export function AlertWrapper({ children }: { children: React.ReactNode }) {
     }, 5000);
   };
 
-  const iconToShow = (variant: 'default' | 'warning') => {
+  const connectionAlertStatus = (isOnline: boolean) => {
+    // Remove any existing connection alerts
+    setAlerts((prev) => prev.filter((alert) => alert.variant !== 'connection'));
+
+    const content = isOnline ? 'Internet connection restored' : 'No internet connection';
+    const id = Date.now();
+
+    setAlerts((prev) => [
+      ...prev,
+      {
+        id,
+        content,
+        variant: 'connection',
+        persistent: !isOnline,
+        isOnline
+      }
+    ]);
+
+    if (isOnline) {
+      setTimeout(() => {
+        setAlerts((prev) => prev.filter((alert) => alert.id !== id));
+      }, 3000);
+    }
+  };
+
+  const iconToShow = (variant: 'default' | 'warning' | 'connection', isOnline?: boolean) => {
     switch (variant) {
       case 'warning':
         return <Icon.Warning size="20" />;
+      case 'connection':
+        return isOnline ? <Icon.CheckCircle size="20" color="#c8ff00" /> : <Icon.LoadingSpin size="20" color='#e95164' />;
       case 'default':
       default:
         return <Icon.CheckCircle size="20" color="#c8ff00" />;
@@ -42,14 +73,19 @@ export function AlertWrapper({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <AlertContext.Provider value={{ addAlert }}>
+    <AlertContext.Provider value={{ addAlert, connectionAlertStatus }}>
       {children}
       <div
         style={{ bottom: isMobile ? '96px' : '24px' }}
         className="fixed z-max left-1/2 transform -translate-x-1/2 flex flex-col gap-2"
       >
-        {alerts.map(({ id, content, variant = 'default' }) => (
-          <Alert.Message key={id} icon={iconToShow(variant)} variant={variant}>
+        {alerts.map(({ id, content, variant = 'default', isOnline }) => (
+          <Alert.Message
+            key={id}
+            icon={iconToShow(variant, isOnline)}
+            variant={variant}
+            isOnline={isOnline}
+          >
             {content}
           </Alert.Message>
         ))}

--- a/src/contexts/_modals.tsx
+++ b/src/contexts/_modals.tsx
@@ -53,6 +53,7 @@ export function ModalProvider({ children }: { children: React.ReactNode }) {
     backup: 'Backup',
     checkContent: 'CheckContent',
     checkLink: 'CheckLink',
+    connectionLost: 'ConnectionLost',
     createArticle: 'CreateArticle',
     createFeed: 'CreateFeed',
     createPost: 'CreatePost',

--- a/src/contexts/_pubky.tsx
+++ b/src/contexts/_pubky.tsx
@@ -54,7 +54,7 @@ type PubkyClientContextType = {
   loginWithAuthUrl: (publicKey: PublicKey) => Promise<string>;
   loginWithMnemonic: (mnemonic: string) => Promise<string>;
   isLoggedIn: () => Promise<boolean>;
-  isSessionActive: () => Promise<boolean>;
+  isSessionActive: () => Promise<{ status: boolean; message: string }>;
   logout: () => boolean;
   signUp: (
     name: string,
@@ -281,14 +281,17 @@ export function PubkyClientWrapper({ children }: { children: React.ReactNode }) 
   const isSessionActive = async () => {
     try {
       const currentPubky = pubky || Utils.storage.get('pubky_public_key');
-      if (!currentPubky) return false;
+      if (!currentPubky) return { status: false, message: 'User not logged in or pubky key not found' };
 
       const publicKey = PublicKey.from(currentPubky);
-      const session = await client.session(publicKey);
-      return Boolean(session);
+      await client.session(publicKey);
+      return { status: true, message: 'Ok' };
     } catch (error) {
+      if (String(error) === 'error sending request') {
+        return { status: true, message: 'connection lost' };
+      }
       console.error('Session Active error:', error);
-      return false;
+      return { status: false, message: String(error) };
     }
   };
 

--- a/src/contexts/_pubky.tsx
+++ b/src/contexts/_pubky.tsx
@@ -46,6 +46,8 @@ type PubkyClientContextType = {
   setSeed: (seed: string | undefined) => void;
   mnemonic: string | undefined;
   setMnemonic: (mnemonic: string | undefined) => void;
+  isOnline: boolean;
+  setIsOnline: (isOnline: boolean) => void;
   profile: PubkyAppUser | undefined;
   newUser: boolean;
   setNewUser: React.Dispatch<React.SetStateAction<boolean>>;
@@ -165,6 +167,7 @@ export function PubkyClientWrapper({ children }: { children: React.ReactNode }) 
   const [specsBuilder, setSpecsBuilder] = useState<PubkySpecsBuilder | undefined>(undefined);
   const [newUser, setNewUser] = useState(false);
   const [seed, setSeed] = useState<string | undefined>((Utils.storage.get('seed') as string | undefined) || undefined);
+  const [isOnline, setIsOnline] = useState(true);
   const [mnemonic, setMnemonic] = useState<string | undefined>(
     (Utils.storage.get('mnemonic') as string | undefined) || undefined
   );
@@ -1415,6 +1418,8 @@ export function PubkyClientWrapper({ children }: { children: React.ReactNode }) 
         signUp,
         setSeed,
         setMnemonic,
+        isOnline,
+        setIsOnline,
         saveProfile,
         saveFeed,
         updateFeed,

--- a/src/contexts/_pubky.tsx
+++ b/src/contexts/_pubky.tsx
@@ -287,10 +287,9 @@ export function PubkyClientWrapper({ children }: { children: React.ReactNode }) 
       await client.session(publicKey);
       return { status: true, message: 'Ok' };
     } catch (error) {
-      if (String(error) === 'error sending request') {
+      if (String(error) === 'error sending request' && typeof window !== 'undefined' && !navigator.onLine) {
         return { status: true, message: 'connection lost' };
       }
-      console.error('Session Active error:', error);
       return { status: false, message: String(error) };
     }
   };


### PR DESCRIPTION
@catch-21 @tipogi
from this call `await client.session(publicKey);` even with connection lost I receive a generic error: `error sending request`, would be nice to receive a more specific message to avoid to show up the modal when this is not the cause