### PR TITLE
fix: protectedProfile routes

### DIFF
--- a/src/components/ProtectedRoutes/index.tsx
+++ b/src/components/ProtectedRoutes/index.tsx
@@ -61,6 +61,20 @@ export default function ProtectedRoutes({ children }: { children: React.ReactNod
 
   const isDynamicPublicRoute = (path: string) => {
     const dynamicPublicRoutes = ['/post/[userId]/[postId]', '/profile/[userId]'];
+    const protectedProfileRoutes = [
+      '/profile/posts',
+      '/profile/replies',
+      '/profile/followers',
+      '/profile/following',
+      '/profile/friends',
+      '/profile/tagged'
+    ];
+
+    // If the path matches any protected profile route, it's not a public route
+    if (protectedProfileRoutes.some((route) => path.startsWith(route))) {
+      return false;
+    }
+
     return dynamicPublicRoutes.some((route) =>
       new RegExp(`^${route.replace(/\[.*?\]/g, '[^/]+').replace(/\//g, '\\/')}$`).test(path)
     );


### PR DESCRIPTION
actually routes like profile/posts, profile/replies are visibile also if you are not loggedin because there are detected as dynamicPublicRoutes profile/[userId]