### PR TITLE
fix: only sort by indexed_at when Sort is Recent

### DIFF
--- a/src/app/home/components/_NewPostsNotifier.tsx
+++ b/src/app/home/components/_NewPostsNotifier.tsx
@@ -50,7 +50,7 @@ export function NewPostsNotifier() {
       // filter out deleted posts and muted users
       const filteredNewPosts = newPostsValue
         .filter((post) => !deletedPosts.includes(post.details.id) && !mutedUsers.includes(post.details.author))
-        .sort((a, b) => b.details.indexed_at - a.details.indexed_at);
+        .sort((a, b) => sort === 'recent' ? b.details.indexed_at - a.details.indexed_at : 0);
 
       // Only add posts that are not already in the timeline
       const uniqueNewPosts = filteredNewPosts.filter(
@@ -119,9 +119,11 @@ export function NewPostsNotifier() {
       // Combine new posts with existing timeline
       const combinedTimeline = [...uniqueNewPosts.reverse(), ...prev];
 
-      // Group reposts and sort chronologically
+      // Group reposts and sort based on current sort setting
       const groupedTimeline = groupReposts(combinedTimeline);
-      const sortedTimeline = groupedTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at);
+      const sortedTimeline = sort === 'recent'
+        ? groupedTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at)
+        : groupedTimeline;
 
       return sortedTimeline;
     });

--- a/src/app/home/components/_NewPostsNotifier.tsx
+++ b/src/app/home/components/_NewPostsNotifier.tsx
@@ -50,7 +50,7 @@ export function NewPostsNotifier() {
       // filter out deleted posts and muted users
       const filteredNewPosts = newPostsValue
         .filter((post) => !deletedPosts.includes(post.details.id) && !mutedUsers.includes(post.details.author))
-        .sort((a, b) => sort === 'recent' ? b.details.indexed_at - a.details.indexed_at : 0);
+        .sort((a, b) => (sort === 'recent' ? b.details.indexed_at - a.details.indexed_at : 0));
 
       // Only add posts that are not already in the timeline
       const uniqueNewPosts = filteredNewPosts.filter(
@@ -121,9 +121,10 @@ export function NewPostsNotifier() {
 
       // Group reposts and sort based on current sort setting
       const groupedTimeline = groupReposts(combinedTimeline);
-      const sortedTimeline = sort === 'recent'
-        ? groupedTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at)
-        : groupedTimeline;
+      const sortedTimeline =
+        sort === 'recent'
+          ? groupedTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at)
+          : groupedTimeline;
 
       return sortedTimeline;
     });

--- a/src/app/home/components/_Timeline.tsx
+++ b/src/app/home/components/_Timeline.tsx
@@ -91,8 +91,10 @@ export const Timeline = () => {
       const combinedTimeline = [...timelineValue, ...groupedNewPosts];
       const finalTimeline = groupReposts(combinedTimeline);
 
-      // Sort the final timeline by indexed_at to maintain chronological order
-      const sortedTimeline = finalTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at);
+      // Only sort by indexed_at for recent sorting, preserve API sorting for popularity
+      const sortedTimeline = sort === 'recent'
+        ? finalTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at)
+        : finalTimeline;
 
       setTimeline(sortedTimeline);
 
@@ -185,12 +187,16 @@ export const Timeline = () => {
           if (existingPost) {
             const updatedTimeline = prev.map((p) => (p.details.id === nexusData.details.id ? nexusData : p));
             const groupedTimeline = groupReposts(updatedTimeline);
-            return groupedTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at);
+            return sort === 'recent'
+              ? groupedTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at)
+              : groupedTimeline;
           }
 
           const newTimeline = [nexusData, ...prev];
           const groupedTimeline = groupReposts(newTimeline);
-          return groupedTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at);
+          return sort === 'recent'
+            ? groupedTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at)
+            : groupedTimeline;
         });
       } catch (error) {
         console.log('Error fetching Nexus data:', error);

--- a/src/app/home/components/_Timeline.tsx
+++ b/src/app/home/components/_Timeline.tsx
@@ -91,7 +91,7 @@ export const Timeline = () => {
       const combinedTimeline = [...timelineValue, ...groupedNewPosts];
       const finalTimeline = groupReposts(combinedTimeline);
 
-      // Only sort by indexed_at for recent sorting, preserve API sorting for popularity
+      // Only sort by indexed_at for recent sorting
       const sortedTimeline =
         sort === 'recent' ? finalTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at) : finalTimeline;
 

--- a/src/app/home/components/_Timeline.tsx
+++ b/src/app/home/components/_Timeline.tsx
@@ -92,9 +92,8 @@ export const Timeline = () => {
       const finalTimeline = groupReposts(combinedTimeline);
 
       // Only sort by indexed_at for recent sorting, preserve API sorting for popularity
-      const sortedTimeline = sort === 'recent'
-        ? finalTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at)
-        : finalTimeline;
+      const sortedTimeline =
+        sort === 'recent' ? finalTimeline.sort((a, b) => b.details.indexed_at - a.details.indexed_at) : finalTimeline;
 
       setTimeline(sortedTimeline);
 


### PR DESCRIPTION
Fixes failing 'can sort by popularity' test by ensuring that `indexed_at` is only used for sorting when the user has Sort by Recent selected, not when sorting by Popularity.