### PR TITLE
Extend notification test

### DIFF
--- a/cypress/e2e/contacts.cy.ts
+++ b/cypress/e2e/contacts.cy.ts
@@ -2,6 +2,7 @@ import { backupDownloadFilePath } from '../support/auth';
 import { slowCypressDown } from 'cypress-slow-down';
 import { searchAndFollowProfile } from '../support/contacts';
 import { HasBackedUp } from '../support/types/enums';
+import { goToProfilePageFromHeader } from '../support/header';
 
 describe('contacts', () => {
   before(() => {
@@ -28,7 +29,7 @@ describe('contacts', () => {
     cy.renameFile(backupDownloadFilePath(), backupDownloadFilePath('pubky1'));
 
     // Copy and store pubky for account 1
-    cy.get('#header-profile-pic').click();
+    goToProfilePageFromHeader();
     cy.get('#profile-copy-pubkey-btn').click();
     cy.saveCopiedPubkyToAlias('pubky1');
     // log pubky for account 1
@@ -47,7 +48,7 @@ describe('contacts', () => {
     cy.renameFile(backupDownloadFilePath(), backupDownloadFilePath('pubky2'));
 
     // Copy and store pubky for account 2
-    cy.get('#header-profile-pic').click();
+    goToProfilePageFromHeader();
     cy.get('#profile-copy-pubkey-btn').click();
     cy.saveCopiedPubkyToAlias('pubky2');
     // log pubky for account 2
@@ -112,7 +113,7 @@ describe('contacts', () => {
     ///
 
     // Check accounts 2 profile (own) for updated following
-    cy.get('#header-profile-pic').click();
+    goToProfilePageFromHeader();
     // tab shows number of following is 1
     cy.get('#profile-tab-following').find('#counter').should('have.text', 1);
 
@@ -156,7 +157,7 @@ describe('contacts', () => {
 
     // Sign in account 1
     cy.signIn(backupDownloadFilePath('pubky1'));
-    cy.get('#header-profile-pic').click();
+    goToProfilePageFromHeader();
 
     // Check account 1 (own) profile for follower
     cy.get('#profile-tab-followers').find('#counter').should('have.text', 1);

--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -11,11 +11,7 @@ import {
 import { slowCypressDown } from 'cypress-slow-down';
 import 'cypress-slow-down/commands';
 import { searchAndFollowProfile, searchForProfileByPubky } from '../support/contacts';
-import {
-  clickFollowButton,
-  unfollowUserByUsername,
-  waitForNotificationDotToDisappear
-} from '../support/profile';
+import { clickFollowButton, unfollowUserByUsername, waitForNotificationDotToDisappear } from '../support/profile';
 import { addProfileTags } from '../support/profile';
 import { checkLatestNotification } from '../support/profile';
 import { HasBackedUp, SkipOnboardingSlides } from '../support/types/enums';

--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -13,7 +13,6 @@ import 'cypress-slow-down/commands';
 import { searchAndFollowProfile, searchForProfileByPubky } from '../support/contacts';
 import {
   clickFollowButton,
-  goToProfilePageFromHeader,
   unfollowUserByUsername,
   waitForNotificationDotToDisappear
 } from '../support/profile';
@@ -21,6 +20,7 @@ import { addProfileTags } from '../support/profile';
 import { checkLatestNotification } from '../support/profile';
 import { HasBackedUp, SkipOnboardingSlides } from '../support/types/enums';
 import { verifyNotificationCounter } from '../support/common';
+import { goToProfilePageFromHeader } from '../support/header';
 
 const profile1 = { username: 'Notif #1', pubkyAlias: 'pubky_1' };
 const profile2 = { username: 'Notif #2', pubkyAlias: 'pubky_2' };

--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -11,7 +11,13 @@ import {
 import { slowCypressDown } from 'cypress-slow-down';
 import 'cypress-slow-down/commands';
 import { searchAndFollowProfile, searchForProfileByPubky } from '../support/contacts';
-import { clickFollowButton, goToProfilePageFromHeader, unfollowUserByUsername, verifyNotificationCounter, waitForNotificationDotToDisappear } from '../support/profile';
+import {
+  clickFollowButton,
+  goToProfilePageFromHeader,
+  unfollowUserByUsername,
+  verifyNotificationCounter,
+  waitForNotificationDotToDisappear
+} from '../support/profile';
 import { addProfileTags } from '../support/profile';
 import { checkLatestNotification } from '../support/profile';
 import { HasBackedUp, SkipOnboardingSlides } from '../support/types/enums';

--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -11,7 +11,7 @@ import {
 import { slowCypressDown } from 'cypress-slow-down';
 import 'cypress-slow-down/commands';
 import { searchAndFollowProfile, searchForProfileByPubky } from '../support/contacts';
-import { clickFollowButton, unfollowUserByUsername, waitForNotificationDotToDisappear } from '../support/profile';
+import { clickFollowButton, goToProfilePageFromHeader, unfollowUserByUsername, verifyNotificationCounter, waitForNotificationDotToDisappear } from '../support/profile';
 import { addProfileTags } from '../support/profile';
 import { checkLatestNotification } from '../support/profile';
 import { HasBackedUp, SkipOnboardingSlides } from '../support/types/enums';
@@ -63,13 +63,8 @@ describe('notifications', () => {
     cy.signOut(HasBackedUp.Yes);
 
     cy.signIn(backupDownloadFilePath(profile2.username));
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    // check notification counter on profile picture is 1
-    cy.get('#header-notification-counter').should('have.text', '1');
-    // navigate to profile 2 profile page
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     // check latest notification on profile page and navigate to profile 1 profile page
     checkLatestNotification([profile1.username, 'followed you'], profile1.username);
 
@@ -81,13 +76,8 @@ describe('notifications', () => {
 
     cy.signIn(backupDownloadFilePath(profile1.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    // check notification counter on profile picture is 1
-    cy.get('#header-notification-counter').should('have.text', '1');
-    // navigate to profile 1 profile page
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     // check latest notification on profile page
     checkLatestNotification([profile2.username, 'is your friend now']);
 
@@ -103,13 +93,8 @@ describe('notifications', () => {
     // * profile 2 checks notification for lost friend
     cy.signIn(backupDownloadFilePath(profile2.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    // check notification counter on profile picture is 1
-    cy.get('#header-notification-counter').should('have.text', '1');
-    // navigate to profile 1 profile page
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     // check latest notification on profile page
     checkLatestNotification([profile1.username, 'is not your friend anymore']);
 
@@ -150,13 +135,8 @@ describe('notifications', () => {
 
     cy.signIn(backupDownloadFilePath(profile2.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    // check notification counter on profile picture is 1
-    cy.get('#header-notification-counter').should('have.text', '1');
-    // navigate to profile 2 profile page
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     // check latest notification on profile page
     checkLatestNotification([profile1.username, 'tagged your profile', profileTag]);
 
@@ -186,11 +166,8 @@ describe('notifications', () => {
 
     cy.signIn(backupDownloadFilePath(profile1.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    cy.get('#header-notification-counter').should('have.text', '1');
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     checkLatestNotification([profile2.username, 'tagged your post', postTag]);
 
     // TODO: add checks for disabled notifications
@@ -214,13 +191,8 @@ describe('notifications', () => {
 
     cy.signIn(backupDownloadFilePath(profile2.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    // check notification counter on profile picture is 1
-    cy.get('#header-notification-counter').should('have.text', '1');
-    // navigate to profile 2 profile page
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     // check latest notification on profile page
     checkLatestNotification([profile1.username, 'mentioned you in a post']);
 
@@ -245,11 +217,8 @@ describe('notifications', () => {
     cy.signOut(HasBackedUp.Yes);
     cy.signIn(backupDownloadFilePath(profile1.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    cy.get('#header-notification-counter').should('have.text', '1');
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     checkLatestNotification([profile2.username, 'replied to your post']);
 
     // TODO: add checks for disabled notifications
@@ -272,11 +241,8 @@ describe('notifications', () => {
     cy.signOut(HasBackedUp.Yes);
     cy.signIn(backupDownloadFilePath(profile1.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    cy.get('#header-notification-counter').should('have.text', '1');
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     checkLatestNotification([profile2.username, 'reposted your post']);
 
     // TODO: add checks for disabled notifications
@@ -306,11 +272,8 @@ describe('notifications', () => {
     cy.signOut(HasBackedUp.Yes);
     cy.signIn(backupDownloadFilePath(profile2.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    cy.get('#header-notification-counter').should('have.text', '1');
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     checkLatestNotification([profile1.username, 'deleted a post you replied to']);
 
     // TODO: add checks for disabled notifications
@@ -341,11 +304,8 @@ describe('notifications', () => {
     cy.signOut(HasBackedUp.Yes);
     cy.signIn(backupDownloadFilePath(profile2.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    cy.get('#header-notification-counter').should('have.text', '1');
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     checkLatestNotification([profile1.username, 'deleted a post you reposted']);
 
     // TODO: add checks for disabled notifications
@@ -375,11 +335,8 @@ describe('notifications', () => {
     cy.signOut(HasBackedUp.Yes);
     cy.signIn(backupDownloadFilePath(profile2.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    cy.get('#header-notification-counter').should('have.text', '1');
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     checkLatestNotification([profile1.username, 'edited a post you replied to']);
 
     // TODO: add checks for disabled notifications
@@ -411,11 +368,8 @@ describe('notifications', () => {
     cy.signOut(HasBackedUp.Yes);
     cy.signIn(backupDownloadFilePath(profile2.username));
     waitForFeedToLoad();
-    // wait and reload if notification counter doesn't show
-    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-    cy.get('#header-notification-counter').should('have.text', '1');
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    verifyNotificationCounter();
+    goToProfilePageFromHeader();
     checkLatestNotification([profile1.username, 'edited a post you reposted']);
 
     // TODO: add checks for disabled notifications

--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -11,7 +11,7 @@ import {
 import { slowCypressDown } from 'cypress-slow-down';
 import 'cypress-slow-down/commands';
 import { searchAndFollowProfile, searchForProfileByPubky } from '../support/contacts';
-import { clickFollowButton, waitForNotificationDotToDisappear } from '../support/profile';
+import { clickFollowButton, unfollowUserByUsername, waitForNotificationDotToDisappear } from '../support/profile';
 import { addProfileTags } from '../support/profile';
 import { checkLatestNotification } from '../support/profile';
 import { HasBackedUp, SkipOnboardingSlides } from '../support/types/enums';
@@ -96,11 +96,31 @@ describe('notifications', () => {
     cy.get('#profile-tab-notifications').click();
     waitForNotificationDotToDisappear();
 
-    // TODO: add checks for unfollowing
     // * profile 1 unfollows profile 2
+    unfollowUserByUsername(profile2.username);
+    cy.signOut(HasBackedUp.Yes);
+
     // * profile 2 checks notification for lost friend
+    cy.signIn(backupDownloadFilePath(profile2.username));
+    waitForFeedToLoad();
+    // wait and reload if notification counter doesn't show
+    cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
+    // check notification counter on profile picture is 1
+    cy.get('#header-notification-counter').should('have.text', '1');
+    // navigate to profile 1 profile page
+    cy.get('#header-profile-pic').click();
+    cy.location('pathname').should('eq', '/profile');
+    // check latest notification on profile page
+    checkLatestNotification([profile1.username, 'is not your friend anymore']);
+
     // * profile 2 unfollows profile 1
+    unfollowUserByUsername(profile1.username);
+    cy.signOut(HasBackedUp.Yes);
+
     // * profile 1 checks absence of notifications
+    cy.signIn(backupDownloadFilePath(profile1.username));
+    waitForFeedToLoad();
+    cy.assertElementDoesNotExist('#header-notification-counter');
 
     // TODO: add checks for disabled notifications
     // * profile 1 disables follow notifications

--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -15,12 +15,12 @@ import {
   clickFollowButton,
   goToProfilePageFromHeader,
   unfollowUserByUsername,
-  verifyNotificationCounter,
   waitForNotificationDotToDisappear
 } from '../support/profile';
 import { addProfileTags } from '../support/profile';
 import { checkLatestNotification } from '../support/profile';
 import { HasBackedUp, SkipOnboardingSlides } from '../support/types/enums';
+import { verifyNotificationCounter } from '../support/common';
 
 const profile1 = { username: 'Notif #1', pubkyAlias: 'pubky_1' };
 const profile2 = { username: 'Notif #2', pubkyAlias: 'pubky_2' };

--- a/cypress/e2e/onboard.cy.ts
+++ b/cypress/e2e/onboard.cy.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { defaultBackupFilename } from '../support/auth';
 import { slowCypressDown } from 'cypress-slow-down';
 import { HasBackedUp, SkipOnboardingSlides } from '../support/types/enums';
+import { goToProfilePageFromHeader } from '../support/header';
 
 describe('onboarding', () => {
   before(() => {
@@ -31,8 +32,7 @@ describe('onboarding', () => {
     cy.signOut(HasBackedUp.Yes);
     cy.signIn(expectedFilePath, '666942');
 
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
+    goToProfilePageFromHeader();
     cy.get('#profile-username-header').invoke('text').should('eq', username);
   });
 
@@ -51,7 +51,7 @@ describe('onboarding', () => {
 
     // check profile name is 'anonymous'
     cy.get('#quick-post-create-content').innerTextShouldContain('anonymous');
-    cy.get('#header-profile-pic').click();
+    goToProfilePageFromHeader();
     cy.get('#profile-username-header').should('have.text', 'anonymous');
   });
 

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -3,6 +3,7 @@ import { slowCypressDown } from 'cypress-slow-down';
 import { HasBackedUp, SkipOnboardingSlides } from '../support/types/enums';
 import { backupDownloadFilePath } from '../support/auth';
 import { searchForProfileByName, searchForProfileByPubky } from '../support/contacts';
+import { goToProfilePageFromHeader } from '../support/header';
 
 describe('profile', () => {
   before(() => {
@@ -21,7 +22,7 @@ describe('profile', () => {
     // todo: add test profile picture upload
 
     // navigate to edit profile page
-    cy.get('#header-profile-pic').click();
+    goToProfilePageFromHeader();
     cy.get('#profile-edit-btn').click();
 
     // edit username and bio and verify changes are persisted
@@ -57,7 +58,7 @@ describe('profile', () => {
 
   it('cancelling edit should not retain any changes made to own profile', () => {
     // navigate to edit profile page
-    cy.get('#header-profile-pic').click();
+    goToProfilePageFromHeader();
     cy.get('#profile-edit-btn').click();
 
     // change name and bio
@@ -83,7 +84,7 @@ describe('profile', () => {
 
   it('can tag own profile', () => {
     // navigate to own profile page
-    cy.get('#header-profile-pic').click();
+    goToProfilePageFromHeader();
 
     // assert 'No tags yet'
     cy.get('#profile-tagged-section').contains('No tags yet');

--- a/cypress/e2e/settings.cy.ts
+++ b/cypress/e2e/settings.cy.ts
@@ -3,6 +3,7 @@ import { slowCypressDown } from 'cypress-slow-down';
 import 'cypress-slow-down/commands';
 import { HasBackedUp } from '../support/types/enums';
 import { backupDownloadFilePath } from '../support/auth';
+import { goToProfilePageFromHeader } from '../support/header';
 
 describe('settings', () => {
   before(() => {
@@ -107,7 +108,7 @@ describe('settings', () => {
     createQuickPost(postContent);
 
     // Copy and store pubky for account 1
-    cy.get('#header-profile-pic').click();
+    goToProfilePageFromHeader();
     cy.get('#profile-copy-pubkey-btn').click();
     cy.saveCopiedPubkyToAlias('pubky1');
     // log pubky for account 2

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,6 @@
 // <reference types="cypress" />
 
+import { goToProfilePageFromHeader } from './header';
 import { checkPostIsIndexed, waitForFeedToLoad } from './posts';
 import { CheckIndexed, HasBackedUp, SkipOnboardingSlides } from './types/enums';
 // ***********************************************
@@ -81,7 +82,7 @@ Cypress.Commands.add(
 Cypress.Commands.add('signOut', (hasBackedUp: HasBackedUp) => {
   cy.location('pathname').then((currentPath) => {
     if (currentPath !== '/profile') {
-      cy.get('#header-profile-pic').click();
+      goToProfilePageFromHeader();
     }
   });
 

--- a/cypress/support/common.ts
+++ b/cypress/support/common.ts
@@ -49,3 +49,10 @@ export const addTagsWithModal = (tags: string[]) => {
     cy.get('#close-btn').click();
   });
 };
+
+export const verifyNotificationCounter = (expectedCount = '1') => {
+  // Wait and reload if the counter doesn't appear
+  cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
+  // Assert the counter text
+  cy.get('#header-notification-counter').should('have.text', expectedCount);
+};

--- a/cypress/support/header.ts
+++ b/cypress/support/header.ts
@@ -1,0 +1,4 @@
+export const goToProfilePageFromHeader = () => {
+    cy.get('#header-profile-pic').click();
+    cy.location('pathname').should('eq', '/profile');
+  };

--- a/cypress/support/header.ts
+++ b/cypress/support/header.ts
@@ -1,4 +1,4 @@
 export const goToProfilePageFromHeader = () => {
-    cy.get('#header-profile-pic').click();
-    cy.location('pathname').should('eq', '/profile');
-  };
+  cy.get('#header-profile-pic').click();
+  cy.location('pathname').should('eq', '/profile');
+};

--- a/cypress/support/profile.ts
+++ b/cypress/support/profile.ts
@@ -142,7 +142,6 @@ export const addProfileTags = (tags: string[]) => {
   cy.get(`#tag-${tags[0]}`).should('be.visible');
 };
 
-
 export const unfollowUserByUsername = (username: string) => {
   cy.get('#header-profile-pic').click();
   cy.location('pathname').should('eq', '/profile');

--- a/cypress/support/profile.ts
+++ b/cypress/support/profile.ts
@@ -155,3 +155,15 @@ export const unfollowUserByUsername = (username: string) => {
     .click();
   cy.get('#list-follow-button').should('contain.text', 'Follow');
 };
+
+export const verifyNotificationCounter = (expectedCount = '1') => {
+  // Wait and reload if the counter doesn't appear
+  cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
+  // Assert the counter text
+  cy.get('#header-notification-counter').should('have.text', expectedCount);
+};
+
+export const goToProfilePageFromHeader = () => {
+  cy.get('#header-profile-pic').click();
+  cy.location('pathname').should('eq', '/profile');
+};

--- a/cypress/support/profile.ts
+++ b/cypress/support/profile.ts
@@ -155,13 +155,6 @@ export const unfollowUserByUsername = (username: string) => {
   cy.get('#list-follow-button').should('contain.text', 'Follow');
 };
 
-export const verifyNotificationCounter = (expectedCount = '1') => {
-  // Wait and reload if the counter doesn't appear
-  cy.waitReloadWhileElementDoesNotExist('#header-notification-counter', 10);
-  // Assert the counter text
-  cy.get('#header-notification-counter').should('have.text', expectedCount);
-};
-
 export const goToProfilePageFromHeader = () => {
   cy.get('#header-profile-pic').click();
   cy.location('pathname').should('eq', '/profile');

--- a/cypress/support/profile.ts
+++ b/cypress/support/profile.ts
@@ -141,3 +141,17 @@ export const addProfileTags = (tags: string[]) => {
   // wait for the tags to be added
   cy.get(`#tag-${tags[0]}`).should('be.visible');
 };
+
+
+export const unfollowUserByUsername = (username: string) => {
+  cy.get('#header-profile-pic').click();
+  cy.location('pathname').should('eq', '/profile');
+  cy.get('#profile-tab-following').click();
+  cy.contains('#list-profile-name', username)
+    .parentsUntil('#profile-list-root')
+    .parent()
+    .find('#list-unfollow-button')
+    .should('be.visible')
+    .click();
+  cy.get('#list-follow-button').should('contain.text', 'Follow');
+};

--- a/cypress/support/profile.ts
+++ b/cypress/support/profile.ts
@@ -1,3 +1,5 @@
+import { goToProfilePageFromHeader } from './header';
+
 interface ProfileField {
   editSelector: string;
   verifySelector: string;
@@ -143,8 +145,7 @@ export const addProfileTags = (tags: string[]) => {
 };
 
 export const unfollowUserByUsername = (username: string) => {
-  cy.get('#header-profile-pic').click();
-  cy.location('pathname').should('eq', '/profile');
+  goToProfilePageFromHeader();
   cy.get('#profile-tab-following').click();
   cy.contains('#list-profile-name', username)
     .parentsUntil('#profile-list-root')

--- a/cypress/support/profile.ts
+++ b/cypress/support/profile.ts
@@ -154,8 +154,3 @@ export const unfollowUserByUsername = (username: string) => {
     .click();
   cy.get('#list-follow-button').should('contain.text', 'Follow');
 };
-
-export const goToProfilePageFromHeader = () => {
-  cy.get('#header-profile-pic').click();
-  cy.location('pathname').should('eq', '/profile');
-};


### PR DESCRIPTION
Extending notification test to cover for "lost friend" notification + tiny refactor helpers to reuse.

- [x] extend notification test to check for lost friend notification (f8c57e869a94065aa4f3c0ddb963d2e133c06ad1) 
- [x] refactor: reuse verifyNotificationCounter and goToProfilePageFromHeader in notification suite (019609e651c571d7d6ff79c2527b022cd8ff95d1) 
- [x] fix formatting (adabd10b55cb942499e677f3e8d3834a075907af) 
- [x] refactor: verifyNotificationCounter -> common.ts (ec165b8b9833be90abc725e96742f5795fcfeee8) 
- [x] refactor: goToProfilePageFromHeader -> header.ts (7b0d640303b8e89d691f67b6bf85a9e3c80a33a5) 
- [x] refactor: reuse goToProfilePageFromHeader() (724827908dabf441f41d09e263ec69f3a5d0015f)

:warning:  **Note:** should not be merged before https://github.com/pubky/pubky-app/pull/1760.