### PR TITLE
tests: Post View retains feed position, used invite code, more..

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # https://github.com/pubky/pubky-stack
-      PUBKY_STACK_REF: 5ff570f356a1a2e3049e46f5df06a98c83cc9076
+      PUBKY_STACK_REF: bdc4fd5127093337871a195ce7dcf2b4442df13a
     strategy:
       matrix:
         browser: [chrome] # [chrome, firefox]

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -149,9 +149,9 @@ jobs:
           spec: jitless/jitless.cy.ts
           browser: ${{ matrix.browser }}
           headed: false
-          summary-title: ${{ matrix.browser }}
+          summary-title: ${{ matrix.browser }}-jitless
           install: false
-          start: npm run start:prod
+          # no need to start the server, it's already running
           wait-on: 'http://localhost:4200'
           wait-on-timeout: 180
 

--- a/cypress/e2e/onboard.cy.ts
+++ b/cypress/e2e/onboard.cy.ts
@@ -56,17 +56,8 @@ describe('onboarding', () => {
   });
 
   // test that invalid invite code is rejected
-  it('should reject invalid invite code', () => {
-    cy.visit('/');
-
-    cy.location('pathname').should('eq', '/onboarding');
-
-    cy.get('#onboarding-create-account-btn').click();
-    cy.location('pathname').should('eq', '/onboarding/intro');
-
-    cy.get('#onboarding-skip-intro-btn').click();
-
-    cy.get('#onboarding-sign-up-link').click();
+  it('should reject invalid or used invite code', () => {
+    cy.visit('/onboarding/sign-up');
     cy.location('pathname').should('eq', '/onboarding/sign-up');
 
     // test that a code with less than 14 characters is rejected
@@ -79,5 +70,17 @@ describe('onboarding', () => {
     cy.get('#onboarding-token-input').type('invalidcode123');
     cy.get('#onboarding-submit-button').click();
     cy.get('#onboarding-token-input-error').should('contain.text', 'Invalid');
+
+    // test a code that is already used is rejected
+    cy.onboardAsNewUser('OneTime', 'I exist to consume an invite code', SkipOnboardingSlides.Yes);
+    cy.signOut(HasBackedUp.No);
+    cy.visit('/onboarding/sign-up');
+    cy.get('#onboarding-name-input').type('NoTime');
+    cy.location('pathname').should('eq', '/onboarding/sign-up');
+    cy.get('@inviteCode').then((usedInviteCode) => {
+      cy.get('#onboarding-token-input').type(usedInviteCode as unknown as string);
+      cy.get('#onboarding-submit-button').click();
+      cy.get('#onboarding-token-input-error').should('contain.text', 'Token already used');
+    });
   });
 });

--- a/cypress/e2e/posts.cy.ts
+++ b/cypress/e2e/posts.cy.ts
@@ -895,7 +895,7 @@ describe('posts', () => {
   });
 
   it('can navigate back to feed from post view', () => {
-    const tallPostContent = "This is a tall post ...\n...\n...\n...\n...\n..."
+    const tallPostContent = 'This is a tall post ...\n...\n...\n...\n...\n...';
     function postSuffix(number: number): string {
       return `${number} - post content suffix`;
     }
@@ -981,6 +981,39 @@ describe('posts', () => {
     cy.window().then((win) => {
       expect(win.scrollY).to.equal(0);
     });
+  });
+
+  // bugfix https://github.com/pubky/pubky-app/issues/1489
+  it('new article modal is shown infront of new post modal', () => {
+    // click in post content area
+    cy.get('#quick-post-create-content').within(() => {
+      cy.get('textarea').should('have.value', '');
+      // click on textarea to expand to view buttons
+      cy.get('textarea').click();
+      // click on new article button
+      cy.get('#article-btn').click();
+    });
+
+    // close new article modal
+    cy.get('#article-modal').should('be.visible');
+    cy.get('#modal-root').within(() => {
+      cy.get('h1').contains('New Article');
+      cy.get('#close-btn').click();
+    });
+
+    // click on new post button (bottom right)
+    cy.get('#new-post-btn').click();
+
+    // click new article button in the new post modal
+    cy.get('#new-post-create-content')
+      .should('be.visible')
+      .within(() => {
+        cy.get('#article-btn').click();
+      });
+
+    // check that new article modal is shown infront of new post modal
+    cy.get('#article-modal').should('be.visible');
+    cy.get('#new-post-create-content').should('not.be.visible');
   });
 
   // todo: check that reply still shown in own profile page

--- a/cypress/e2e/posts.cy.ts
+++ b/cypress/e2e/posts.cy.ts
@@ -894,6 +894,95 @@ describe('posts', () => {
     cy.location('pathname').should('eq', '/sign-in');
   });
 
+  it('can navigate back to feed from post view', () => {
+    const tallPostContent = "This is a tall post ...\n...\n...\n...\n...\n..."
+    function postSuffix(number: number): string {
+      return `${number} - post content suffix`;
+    }
+    const posts = [
+      `${tallPostContent} ${postSuffix(1)}! ${Date.now()}`,
+      `${tallPostContent} ${postSuffix(2)}! ${Date.now()}`,
+      `${tallPostContent} ${postSuffix(3)}! ${Date.now()}`,
+      `${tallPostContent} ${postSuffix(4)}! ${Date.now()}`
+    ];
+
+    // create 5 new posts
+    posts.forEach((post) => {
+      createQuickPost(post);
+    });
+
+    // * Open post view and navigate back to feed retaining scroll position
+
+    cy.findPostInFeed(0, postSuffix(1)).then(($post) => {
+      const yPosition = $post.position().top;
+      // scroll down to the first post
+      cy.scrollTo(0, yPosition - 100);
+
+      // Store the current y scroll position as a Cypress alias for later assertion
+      cy.wrap(yPosition).as('feedScrollY');
+
+      // click on the post
+      cy.wrap($post).click();
+    });
+
+    // check that we are on the post view page
+    cy.location('pathname').should('contain', '/post/');
+
+    // check that the post content is visible
+    cy.get('#post-view-modal')
+      .get('#post-container')
+      .get('#post-content-text')
+      .should('be.visible')
+      .innerTextShouldContain(postSuffix(4));
+
+    // use browser back button to navigate back to feed
+    cy.go('back');
+
+    // check that we are on the feed page
+    cy.location('pathname').should('contain', '/home');
+
+    // check that the post is still visible in feed
+    cy.findPostInFeed(0, postSuffix(1)).should('be.visible');
+    // check y scroll position is the same as before the post view
+    cy.get('@feedScrollY').then((scrollY) => {
+      cy.window().then((win) => {
+        // Assert that the scrollY value is within 1% tolerance of the original scrollY
+        const scrollYValue = scrollY as unknown as number;
+        const tolerance = Math.abs(scrollYValue) * 0.01;
+        expect(win.scrollY).to.be.closeTo(scrollYValue, tolerance);
+      });
+    });
+
+    // * Open post and navigate home to top of feed
+
+    // click on the first post created
+    cy.findPostInFeed(0, postSuffix(1)).then(($post) => {
+      const yPosition = $post.position().top;
+      // scroll down to the first post
+      cy.scrollTo(0, yPosition - 100);
+      // click on the post
+      cy.wrap($post).click();
+    });
+
+    // check that we are on the post view page
+    cy.location('pathname').should('contain', '/post/');
+
+    // use Pubky logo to navigate back to feed
+    // TODO: why are there two header logos
+    cy.get('#post-view-modal').find('#header-logo').first().click();
+
+    // check that we are on the feed page
+    cy.location('pathname').should('contain', '/home');
+
+    // check that the last is visible in feed
+    cy.findPostInFeed(0, postSuffix(4)).should('be.visible');
+
+    // check y scroll position is 0
+    cy.window().then((win) => {
+      expect(win.scrollY).to.equal(0);
+    });
+  });
+
   // todo: check that reply still shown in own profile page
   // todo: test 'Show n new posts' button
 });

--- a/cypress/e2e/posts.cy.ts
+++ b/cypress/e2e/posts.cy.ts
@@ -92,39 +92,16 @@ describe('posts', () => {
   });
 
   it('can post with maximum character limit (1000)', () => {
-    const postContent =
-      'I can make a really looooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      `ooooooooooooooooooooooooooooooooooooooooooog post! ${Date.now()}`;
+    // Helper function to generate 'o' characters
+    const generateOs = (count: number): string => 'o'.repeat(count);
 
-    const expectedPostContent =
-      'I can make a really looooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooooooooooooooooooooooo' +
-      'oooooooooooooooooooooooooooooooo...Show more';
+    // 958 'o' characters makes 1000 in total
+    const postContent = `I can make a really l${generateOs(958)}g post! ${Date.now()}`;
 
+    // The truncation happens at 479 'o' characters
+    const expectedPostContent = `I can make a really l${generateOs(479)}...Show more`;
+
+    // create post and verify the counter is displayed correctly
     createQuickPost(postContent);
 
     // verify the post is displayed correctly in feed

--- a/cypress/e2e/posts.cy.ts
+++ b/cypress/e2e/posts.cy.ts
@@ -91,6 +91,43 @@ describe('posts', () => {
     latestPostInFeedContentEq(postContent);
   });
 
+  it('can edit a post', () => {
+    const postContent = `This post will be edited! ${Date.now()}`;
+    const editSuffix = ' ..got edited';
+    const tags = ['welkin', 'octan'];
+    const editTag = ['wolfram'];
+    createQuickPostWithTags(postContent, tags);
+
+    // verify the post is displayed correctly in feed
+    cy.findFirstPostInFeed(CheckIndexed.Yes).within(() => {
+      // open post menu and check edit is available
+      cy.get('#menu-btn').should('be.visible').click();
+      cy.get('#post-tooltip-menu')
+        .should('be.visible')
+        .within(() => {
+          cy.get('#edit-post').should('be.visible').click();
+        });
+    });
+
+    // edit the post and add tags
+    cy.get('#modal-root')
+      .should('be.visible')
+      .within(() => {
+        cy.get('h1').contains('Edit Post').should('be.visible');
+        cy.get('textarea').type(editSuffix);
+        cy.get('textarea').should('have.value', postContent + editSuffix);
+
+        // check that tags cannot be edited from this edit modal
+        cy.get('#show-add-tag-input-btn').should('be.visible').click();
+        cy.get('#add-tag-input').should('not.exist');
+
+        cy.get('#post-btn').click();
+      });
+
+    // verify the post is displayed correctly in feed
+    latestPostInFeedContentEq(postContent + editSuffix);
+  });
+
   it('can post with maximum character limit (1000)', () => {
     // Helper function to generate 'o' characters
     const generateOs = (count: number): string => 'o'.repeat(count);

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -2,13 +2,28 @@ import { backupDownloadFilePath } from '../support/auth';
 import { slowCypressDown } from 'cypress-slow-down';
 // registers the cy.slowDown and cy.slowDownEnd commands
 import 'cypress-slow-down/commands';
-import { createQuickPost, createQuickPostWithTags } from '../support/posts';
+import { createQuickPost, createQuickPostWithTags, waitForFeedToLoad } from '../support/posts';
 import { CheckIndexed } from '../support/types/enums';
+
+const username = 'Mr Search';
 
 describe('search', () => {
   before(() => {
     slowCypressDown();
     cy.deleteDownloadsFolder();
+    cy.onboardAsNewUser(username, 'I like to search');
+    cy.backupRecoveryFile();
+    cy.renameFile(backupDownloadFilePath(), backupDownloadFilePath(username));
+  });
+
+  beforeEach(() => {
+    // sign in if not already
+    cy.location('pathname').then((currentPath) => {
+      if (currentPath !== '/home') {
+        cy.signIn(backupDownloadFilePath(username));
+        waitForFeedToLoad();
+      }
+    });
   });
 
   // TODO: continue test once search bug is fixed, see https://github.com/pubky/pubky-app/issues/1427
@@ -21,9 +36,6 @@ describe('search', () => {
     const postTag2 = `Post with tag2 ${Date.now()}`;
     const postTags2and3 = `Post with tag2 and tag3 ${Date.now()}`;
     const postNoTags = `Post with no tags ${Date.now()}`;
-
-    // sign up as new user
-    cy.onboardAsNewUser('Mr Search', 'I like to search');
 
     // create a post with tag1
     createQuickPostWithTags(postTag1, [tag1]);
@@ -40,27 +52,49 @@ describe('search', () => {
     // search for a single tag
     cy.get('#header-search-input').type(tag1).type('{enter}');
     // confirm tag remains displayed in the search bar
-    cy.get('#header-search-input').innerTextContains(tag1);
+    cy.get('#header-search').innerTextShouldContain(tag1);
 
     // confirm one post is seen in result
     cy.get('#post-search-results').children().should('have.length', 1);
-    // confirm correct post is seen in result
-    cy.findPostInSearchResults(postTag1).innerTextShouldContain(postTag1).innerTextShouldNotContain(postTag2);
+    cy.log('postTag1', postTag1);
+    // confirm correct post is seen in result and click it
+    cy.findPostInSearchResults(postTag1).innerTextShouldContain(postTag1).innerTextShouldNotContain(postTag2).click();
+
+    // check that we are on the post view page
+    cy.location('pathname').should('contain', '/post/');
+
+    // wait a short while and check that the post is still visible and no redirect has occurred
+    // verify bugfix https://github.com/pubky/pubky-app/pull/1786
+    cy.wait(500);
+    cy.location('pathname').should('contain', '/post/');
+
+    // check that the post content is visible
+    cy.get('#post-view-modal')
+      .get('#post-container')
+      .get('#post-content-text')
+      .should('be.visible')
+      .innerTextShouldContain(postTag1);
+
+    // navigate back to search results
+    cy.go('back');
+
+    // check that we are on the search results page
+    cy.location('pathname').should('contain', '/search');
+
+    // check that the post is still visible in search results
+    cy.findPostInSearchResults(postTag1).should('be.visible');
 
     // search for two tags
-    // TODO: FAILS here because of multi-tag search bug, see https://github.com/pubky/pubky-app/issues/1427
-    // cy.get('#header-search-input').type(tag2).type('{enter}');
+    cy.get('#header-search-input').type(tag2).type('{enter}');
     // confirm both tags remain displayed in the search bar
-    // cy.get('#header-search-input').innerTextContains(tag1).and('innerTextContains', tag2);
+    cy.get('#header-search').innerTextShouldContain(tag1).innerTextShouldContain(tag2);
 
     // confirm three posts are seen in result
-    // cy.get('#post-search-results')
-    //   .children()
-    //   .should('have.length', 3);
+    cy.get('#post-search-results').children().should('have.length', 3);
     // confirm correct posts are seen in result
-    // cy.findPostInSearchResults(postTag1).innerTextShouldContain(tag1);
-    // cy.findPostInSearchResults(postTag2).innerTextShouldContain(tag2);
-    // cy.findPostInSearchResults(postTags2and3).innerTextShouldContain(tag2).innerTextShouldContain(tag3);
+    cy.findPostInSearchResults(postTag1).innerTextShouldContain(tag1);
+    cy.findPostInSearchResults(postTag2).innerTextShouldContain(tag2);
+    cy.findPostInSearchResults(postTags2and3).innerTextShouldContain(tag2).innerTextShouldContain(tag3);
 
     // remove first tag from search
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -53,6 +53,7 @@ Cypress.Commands.add(
       }
     }).then((response) => {
       const inviteCode = response.body;
+      cy.wrap(inviteCode).as('inviteCode');
       cy.get('#onboarding-token-input').type(inviteCode);
     });
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -233,7 +233,7 @@ export default function Header({ title }: HeaderProps) {
       </div>
       {pubky ? (
         <div className="w-full flex justify-between gap-6">
-          <Input.Search>
+          <Input.Search id="header-search">
             {searchTags && (
               <Input.SearchTags ref={refTagsContainer}>
                 {searchTags.map((searchTag, index) => (

--- a/src/components/Modal/_CreateArticle/index.tsx
+++ b/src/components/Modal/_CreateArticle/index.tsx
@@ -29,7 +29,7 @@ export default function CreateArticle({ showModal, setShowModal, setShowModalPos
       closeModal={handleClose}
       className="max-h-[90vh] overflow-y-auto max-w-[1200px] scrollbar-thin scrollbar-webkit"
     >
-      <Modal.CloseAction onClick={handleClose} />
+      <Modal.CloseAction id="close-btn" onClick={handleClose} />
       <div id="article-modal" className="flex flex-col gap-4">
         <Modal.Header title="New Article" />
         <ContentCreateArticle


### PR DESCRIPTION
- Navigating back to feed to retain position, and using Pubky logo to go home.
- Used invite code is rejected
- Create article from new post button - because New Post modal stayed visible infant of New Article modal, see https://github.com/pubky/pubky-app/issues/1489
- Can edit a post and cannot edit tags in the Edit Post modal
- Add check for navigating to searched tag result in post view for bugfix in PR #1786