### PR TITLE
feat: EXPERIMENTAL in-browser post translation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,17 +3,18 @@ NEXT_PUBLIC_HOMESERVER=8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo
 NEXT_PUBLIC_NEXUS=http://localhost:8080
 NEXT_PUBLIC_TESTNET=true
 NEXT_PUBLIC_DEFAULT_HTTP_RELAY=http://localhost:15412/link/
+
+# OPEN VARIABLES - MAINNET
+# NEXT_PUBLIC_HOMESERVER=8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty
+# NEXT_PUBLIC_NEXUS=https://nexus.pubky.app
+# NEXT_PUBLIC_TESTNET=false
+# NEXT_PUBLIC_DEFAULT_HTTP_RELAY=https://httprelay.pubky.app/link
+
 NEXT_PUBLIC_PKARR_RELAYS=["https://pkarr.pubky.app", "https://pkarr.pubky.org"]
 NEXT_PUBLIC_MODERATION_ID=euwmq57zefw5ynnkhh37b3gcmhs7g3cptdbw1doaxj1pbmzp3wro
 NEXT_PUBLIC_MODERATED_TAGS=["nudity"]
 NEXT_PUBLIC_CONFCOLOUR=blue
 NEXT_PUBLIC_PLAUSIBLE=beta.pubky.app
-
-# OPEN VARIABLES - MAINNET
-# NEXT_PUBLIC_HOMESERVER=ufibwbmed6jeq9k4p583go95wofakh9fwpp4k734trq79pd9u1uy
-# NEXT_PUBLIC_NEXUS=https://nexus.staging.pubky.app
-# NEXT_PUBLIC_TESTNET=false
-# NEXT_PUBLIC_DEFAULT_HTTP_RELAY=https://httprelay.staging.pubky.app/link
 
 # SECRET VARIABLES
 BASE_URL_SUPPORT=

--- a/src/components/Post/_Content.tsx
+++ b/src/components/Post/_Content.tsx
@@ -15,6 +15,7 @@ import { useFileLoading } from '@/hooks/useFileLoading';
 import Link from 'next/link';
 import { PubkyAppPostKind } from 'pubky-app-specs';
 import { useModal } from '@/contexts';
+import { useTranslation } from '@/hooks/useTranslation';
 
 interface PostProps extends React.HTMLAttributes<HTMLDivElement> {
   post: PostView;
@@ -103,11 +104,14 @@ export default function Content({
       return { body: cleanedText };
     }
   })();
+  const textToTranslate = parsedContent?.body || cleanedText;
   const textToMinified = parsedContent?.body || cleanedText;
   const minifiedContent = Utils.minifyContent(textToMinified, 7, 500);
   const contentText = fullContent ? textToMinified : minifiedContent;
 
   const showMore = !fullContent && textToMinified !== minifiedContent;
+
+  const { needsTranslation, isTranslating, translatedText, handleTranslate } = useTranslation(textToTranslate);
 
   return (
     <div className="w-full relative">
@@ -181,6 +185,34 @@ export default function Content({
             Show more
           </Link>
         )}
+
+        {/* 👇 CORRECT PLACEMENT FOR THE TRANSLATION UI 👇 */}
+        <div className="mt-3 cursor-default" onClick={(e) => e.stopPropagation()}>
+          {needsTranslation && (
+            <Button.Medium
+              onClick={handleTranslate}
+              disabled={isTranslating}
+              className="text-opacity-70 hover:text-opacity-100"
+            >
+              {isTranslating ? (
+                <>
+                  <Icon.LoadingSpin size="16" />
+                  <span className="ml-2">Translating...</span>
+                </>
+              ) : (
+                'Translate'
+              )}
+            </Button.Medium>
+          )}
+          {translatedText && (
+            <div className="mt-2 p-3 bg-white bg-opacity-5 rounded-lg border border-white border-opacity-10">
+              <Typography.Body variant="small" className="text-white text-opacity-80 whitespace-pre-wrap">
+                {translatedText}
+              </Typography.Body>
+            </div>
+          )}
+        </div>
+
         <div>
           <div>
             {!replyView && String(post?.details?.kind) !== PubkyAppPostKind[1].toLocaleLowerCase() && (

--- a/src/components/Post/_Content.tsx
+++ b/src/components/Post/_Content.tsx
@@ -120,7 +120,8 @@ export default function Content({
     handleHideTranslation,
     isTranslationShown,
     canTranslate,
-    translationError
+    translationError,
+    getUiLabel
   } = useTranslation(textToTranslate);
 
   return (
@@ -206,10 +207,10 @@ export default function Content({
               {isTranslating ? (
                 <span className="flex items-center gap-1">
                   <Icon.LoadingSpin size="12" />
-                  <span className="ml-2">Translating...</span>
+                  <span className="ml-2">{getUiLabel('translating')}</span>
                 </span>
               ) : (
-                'Translate post'
+                getUiLabel('translate')
               )}
             </span>
           )}
@@ -222,7 +223,7 @@ export default function Content({
                 onClick={handleHideTranslation}
                 className="text-sm cursor-pointer underline text-[#C8FF00]/80 hover:text-[#C8FF00]"
               >
-                Hide translation
+                {getUiLabel('hide')}
               </span>
               {translatedText && (
                 <div className="mt-2 p-3 bg-white bg-opacity-5 rounded-lg border border-white border-opacity-10">

--- a/src/components/Post/_Content.tsx
+++ b/src/components/Post/_Content.tsx
@@ -111,7 +111,17 @@ export default function Content({
 
   const showMore = !fullContent && textToMinified !== minifiedContent;
 
-  const { needsTranslation, isTranslating, translatedText, handleTranslate } = useTranslation(textToTranslate);
+  const {
+    needsTranslation,
+    isTranslating,
+    translatedText,
+    translatedLines,
+    handleTranslate,
+    handleHideTranslation,
+    isTranslationShown,
+    canTranslate,
+    translationError
+  } = useTranslation(textToTranslate);
 
   return (
     <div className="w-full relative">
@@ -186,30 +196,42 @@ export default function Content({
           </Link>
         )}
 
-        {/* 👇 CORRECT PLACEMENT FOR THE TRANSLATION UI 👇 */}
         <div className="mt-3 cursor-default" onClick={(e) => e.stopPropagation()}>
-          {needsTranslation && (
-            <Button.Medium
+          {!isTranslationShown && needsTranslation && canTranslate && (
+            <span
               onClick={handleTranslate}
-              disabled={isTranslating}
-              className="text-opacity-70 hover:text-opacity-100"
+              className="text-sm cursor-pointer underline text-[#C8FF00]/80 hover:text-[#C8FF00]"
+              aria-disabled={isTranslating}
             >
               {isTranslating ? (
-                <>
-                  <Icon.LoadingSpin size="16" />
+                <span className="flex items-center gap-1">
+                  <Icon.LoadingSpin size="12" />
                   <span className="ml-2">Translating...</span>
-                </>
+                </span>
               ) : (
-                'Translate'
+                'Translate post'
               )}
-            </Button.Medium>
+            </span>
           )}
-          {translatedText && (
-            <div className="mt-2 p-3 bg-white bg-opacity-5 rounded-lg border border-white border-opacity-10">
-              <Typography.Body variant="small" className="text-white text-opacity-80 whitespace-pre-wrap">
-                {translatedText}
-              </Typography.Body>
-            </div>
+          {translationError && !isTranslationShown && (
+            <div className="mt-2 text-xs text-red-400">{translationError}</div>
+          )}
+          {isTranslationShown && (
+            <>
+              <span
+                onClick={handleHideTranslation}
+                className="text-sm cursor-pointer underline text-[#C8FF00]/80 hover:text-[#C8FF00]"
+              >
+                Hide translation
+              </span>
+              {translatedText && (
+                <div className="mt-2 p-3 bg-white bg-opacity-5 rounded-lg border border-white border-opacity-10">
+                  <Typography.Body variant="small" className="text-white text-opacity-80 whitespace-pre-wrap">
+                    {translatedLines && translatedLines.map((line, idx) => <Parsing key={idx}>{line}</Parsing>)}
+                  </Typography.Body>
+                </div>
+              )}
+            </>
           )}
         </div>
 

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -62,6 +62,30 @@ function restoreUrlsFromPlaceholders(text: string, urls: string[]): string {
   return text.replace(/__URL(\d+)__/g, (match, idx) => urls[Number(idx)] || match);
 }
 
+// Translate UI labels using the same translation API as content
+const uiLabelText: Record<'translate' | 'translating' | 'hide', string> = {
+  translate: 'Translate post',
+  translating: 'Translating...',
+  hide: 'Hide translation'
+};
+
+const uiLabelCache: Record<string, Record<string, string>> = {};
+
+async function translateUiLabel(label: 'translate' | 'translating' | 'hide', targetLang: string): Promise<string> {
+  if (targetLang === 'en') return uiLabelText[label];
+  if (uiLabelCache[targetLang]?.[label]) return uiLabelCache[targetLang][label];
+  if (typeof window !== 'undefined' && 'Translator' in self) {
+    try {
+      const translator = await self.Translator!.create({ sourceLanguage: 'en', targetLanguage: targetLang });
+      const translated = await translator.translate(uiLabelText[label]);
+      if (!uiLabelCache[targetLang]) uiLabelCache[targetLang] = {};
+      uiLabelCache[targetLang][label] = translated;
+      return translated;
+    } catch {}
+  }
+  return uiLabelText[label];
+}
+
 export const useTranslation = (originalText: string, getUsernameFromPk?: (pk: string) => string | undefined) => {
   const [isApiAvailable, setIsApiAvailable] = useState(false);
   const [needsTranslation, setNeedsTranslation] = useState(false);
@@ -71,6 +95,7 @@ export const useTranslation = (originalText: string, getUsernameFromPk?: (pk: st
   const [isTranslationShown, setIsTranslationShown] = useState(false);
   const [canTranslate, setCanTranslate] = useState(true);
   const [translationError, setTranslationError] = useState<string | null>(null);
+  const [uiLabels, setUiLabels] = useState<Record<'translate' | 'translating' | 'hide', string>>(uiLabelText);
 
   useEffect(() => {
     if ('Translator' in self && 'LanguageDetector' in self) {
@@ -81,6 +106,28 @@ export const useTranslation = (originalText: string, getUsernameFromPk?: (pk: st
         hasLanguageDetector: 'LanguageDetector' in self
       });
     }
+  }, []);
+
+  // Translate UI labels on mount or when language changes
+  useEffect(() => {
+    const targetLang = getTargetLanguage();
+    if (targetLang === 'en') {
+      setUiLabels(uiLabelText);
+      return;
+    }
+    let cancelled = false;
+    Promise.all([
+      translateUiLabel('translate', targetLang),
+      translateUiLabel('translating', targetLang),
+      translateUiLabel('hide', targetLang)
+    ]).then(([translate, translating, hide]) => {
+      if (!cancelled) {
+        setUiLabels({ translate, translating, hide });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -188,6 +235,10 @@ export const useTranslation = (originalText: string, getUsernameFromPk?: (pk: st
     setTranslatedText(null);
   }, []);
 
+  function getUiLabel(label: 'translate' | 'translating' | 'hide'): string {
+    return uiLabels[label];
+  }
+
   return {
     needsTranslation,
     isTranslating,
@@ -197,6 +248,7 @@ export const useTranslation = (originalText: string, getUsernameFromPk?: (pk: st
     handleHideTranslation,
     isTranslationShown,
     canTranslate,
-    translationError
+    translationError,
+    getUiLabel
   };
 };

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -16,12 +16,61 @@ interface CustomWindow extends Window {
 
 declare const self: CustomWindow;
 
-export const useTranslation = (originalText: string) => {
+function getTargetLanguage(): string {
+  let lang =
+    navigator.languages && navigator.languages.length > 0 ? navigator.languages[0] : navigator.language || 'en';
+  if (typeof lang === 'string') {
+    return lang.split('-')[0];
+  }
+  return 'en';
+}
+
+// Remove lines starting with pk: or other non-linguistic tokens
+function cleanTextForTranslation(text: string): string {
+  if (!text) return '';
+  // Remove lines that start with pk: or are just pubky keys
+  return text
+    .split('\n')
+    .filter((line) => !/^pk:[a-z0-9]+$/i.test(line.trim()))
+    .join('\n')
+    .trim();
+}
+
+// Extract pk: line and return { pk, rest }
+function extractPkAndRest(text: string): { pk: string | null; rest: string } {
+  if (!text) return { pk: null, rest: '' };
+  const lines = text.split('\n');
+  if (lines[0].trim().startsWith('pk:')) {
+    return { pk: lines[0].trim(), rest: lines.slice(1).join('\n').trim() };
+  }
+  return { pk: null, rest: text };
+}
+
+// Replace URLs with placeholders before translation, then restore them after
+function replaceUrlsWithPlaceholders(text: string): { processed: string; urls: string[] } {
+  const urlRegex =
+    /(https?:\/\/[a-zA-Z0-9-._~:/?#[\]@!$&'()*+,;=%]+|(?:www\.)?([a-zA-Z0-9][a-zA-Z0-9-]*\.)+[a-zA-Z]{2,}(?:\/[\w\-._~:/?#[\]@!$&'()*+,;=%]*)?)/g;
+  const urls: string[] = [];
+  let processed = text.replace(urlRegex, (url) => {
+    urls.push(url);
+    return `__URL${urls.length - 1}__`;
+  });
+  return { processed, urls };
+}
+
+function restoreUrlsFromPlaceholders(text: string, urls: string[]): string {
+  return text.replace(/__URL(\d+)__/g, (match, idx) => urls[Number(idx)] || match);
+}
+
+export const useTranslation = (originalText: string, getUsernameFromPk?: (pk: string) => string | undefined) => {
   const [isApiAvailable, setIsApiAvailable] = useState(false);
   const [needsTranslation, setNeedsTranslation] = useState(false);
   const [translatedText, setTranslatedText] = useState<string | null>(null);
   const [isTranslating, setIsTranslating] = useState(false);
   const [sourceLang, setSourceLang] = useState<string | null>(null);
+  const [isTranslationShown, setIsTranslationShown] = useState(false);
+  const [canTranslate, setCanTranslate] = useState(true);
+  const [translationError, setTranslationError] = useState<string | null>(null);
 
   useEffect(() => {
     if ('Translator' in self && 'LanguageDetector' in self) {
@@ -38,25 +87,43 @@ export const useTranslation = (originalText: string) => {
     setNeedsTranslation(false);
     setTranslatedText(null);
     setSourceLang(null);
+    setIsTranslationShown(false);
+    setCanTranslate(true);
+    setTranslationError(null);
 
     if (isApiAvailable && originalText) {
       const detectLanguage = async () => {
         try {
+          const { rest } = extractPkAndRest(originalText);
+          const cleaned = cleanTextForTranslation(rest);
           const detector = await self.LanguageDetector!.create();
-          const results = await detector.detect(originalText);
+          const results = await detector.detect(cleaned);
 
           if (results.length > 0 && results[0].detectedLanguage) {
             const detectedCode = results[0].detectedLanguage;
-
-            if (detectedCode && !detectedCode.startsWith('en')) {
-              setNeedsTranslation(true);
-              setSourceLang(detectedCode);
+            const targetLang = getTargetLanguage();
+            // Only show translation if detected language is different from target
+            if (detectedCode && detectedCode.split('-')[0] !== targetLang.split('-')[0]) {
+              // Try to create the translator to check if it's possible
+              try {
+                await self.Translator!.create({ sourceLanguage: detectedCode, targetLanguage: targetLang });
+                setNeedsTranslation(true);
+                setSourceLang(detectedCode);
+                setCanTranslate(true);
+              } catch (err) {
+                setNeedsTranslation(false);
+                setCanTranslate(false);
+              }
             } else {
+              setNeedsTranslation(false);
+              setCanTranslate(false);
             }
           } else {
+            setCanTranslate(false);
             console.warn('[useTranslation] WARN: Detection returned no results.');
           }
         } catch (error) {
+          setCanTranslate(false);
           console.error(
             '[useTranslation] CRITICAL: Language detection failed. Device may be ineligible or another error occurred.',
             error
@@ -73,33 +140,63 @@ export const useTranslation = (originalText: string) => {
       console.error(
         `[useTranslation] ERROR: Cannot translate. Missing text or source language. Has text: ${!!originalText}, Has sourceLang: ${!!sourceLang}`
       );
+      setTranslationError('Unable to translate this text.');
       return;
     }
 
-    console.log(`[useTranslation] Translating from "${sourceLang}"...`);
+    const targetLang = getTargetLanguage();
     setIsTranslating(true);
     setTranslatedText(null);
+    setIsTranslationShown(false);
+    setTranslationError(null);
 
     try {
+      const { pk, rest } = extractPkAndRest(originalText);
+      const cleaned = cleanTextForTranslation(rest);
+      // Replace URLs with placeholders
+      const { processed: cleanedWithPlaceholders, urls } = replaceUrlsWithPlaceholders(cleaned);
       const translator = await self.Translator!.create({
         sourceLanguage: sourceLang,
-        targetLanguage: 'en'
+        targetLanguage: targetLang
       });
-
-      const output = await translator.translate(originalText);
-      setTranslatedText(output);
+      let output = await translator.translate(cleanedWithPlaceholders);
+      // Restore URLs in the translated output
+      output = restoreUrlsFromPlaceholders(output, urls);
+      // Use username if resolver is provided, else fallback to pk:... line
+      let firstLine = '';
+      if (pk) {
+        let pkValue = pk.replace(/^pk:/, '').trim();
+        let username = getUsernameFromPk ? getUsernameFromPk(pkValue) : undefined;
+        firstLine = username ? `@${username}` : pk;
+      }
+      let translated = firstLine ? `${firstLine}\n${output}` : output;
+      setTranslatedText(translated);
       setNeedsTranslation(false);
+      setIsTranslationShown(true);
+      setTranslationError(null);
     } catch (error) {
+      setTranslationError('Unable to translate this text. The original will be shown.');
       console.error(`[useTranslation] CRITICAL: Translation from '${sourceLang}' failed.`, error);
     } finally {
       setIsTranslating(false);
     }
-  }, [originalText, sourceLang]);
+  }, [originalText, sourceLang, getUsernameFromPk]);
+
+  const handleHideTranslation = useCallback(() => {
+    setIsTranslationShown(false);
+    setNeedsTranslation(true);
+    setTranslatedText(null);
+  }, []);
 
   return {
     needsTranslation,
     isTranslating,
     translatedText,
-    handleTranslate
+    translatedLines: translatedText ? translatedText.split('\n') : null,
+    handleTranslate,
+    handleHideTranslation,
+    isTranslationShown,
+    canTranslate,
+    translationError
   };
 };

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -3,10 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 // Define the types for the APIs we are using.
 interface CustomWindow extends Window {
   Translator?: {
-    create: (options: {
-      sourceLanguage: string;
-      targetLanguage: string;
-    }) => Promise<{
+    create: (options: { sourceLanguage: string; targetLanguage: string }) => Promise<{
       translate: (text: string) => Promise<string>;
     }>;
   };
@@ -31,8 +28,8 @@ export const useTranslation = (originalText: string) => {
       setIsApiAvailable(true);
     } else {
       console.error('[useTranslation] ERROR: One or both APIs are missing.', {
-          hasTranslator: 'Translator' in self,
-          hasLanguageDetector: 'LanguageDetector' in self
+        hasTranslator: 'Translator' in self,
+        hasLanguageDetector: 'LanguageDetector' in self
       });
     }
   }, []);
@@ -50,17 +47,20 @@ export const useTranslation = (originalText: string) => {
 
           if (results.length > 0 && results[0].detectedLanguage) {
             const detectedCode = results[0].detectedLanguage;
-            
+
             if (detectedCode && !detectedCode.startsWith('en')) {
               setNeedsTranslation(true);
               setSourceLang(detectedCode);
             } else {
             }
           } else {
-             console.warn('[useTranslation] WARN: Detection returned no results.');
+            console.warn('[useTranslation] WARN: Detection returned no results.');
           }
         } catch (error) {
-          console.error('[useTranslation] CRITICAL: Language detection failed. Device may be ineligible or another error occurred.', error);
+          console.error(
+            '[useTranslation] CRITICAL: Language detection failed. Device may be ineligible or another error occurred.',
+            error
+          );
         }
       };
 
@@ -70,8 +70,10 @@ export const useTranslation = (originalText: string) => {
 
   const handleTranslate = useCallback(async () => {
     if (!originalText || !sourceLang) {
-        console.error(`[useTranslation] ERROR: Cannot translate. Missing text or source language. Has text: ${!!originalText}, Has sourceLang: ${!!sourceLang}`);
-        return;
+      console.error(
+        `[useTranslation] ERROR: Cannot translate. Missing text or source language. Has text: ${!!originalText}, Has sourceLang: ${!!sourceLang}`
+      );
+      return;
     }
 
     console.log(`[useTranslation] Translating from "${sourceLang}"...`);

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -1,0 +1,103 @@
+import { useState, useEffect, useCallback } from 'react';
+
+// Define the types for the APIs we are using.
+interface CustomWindow extends Window {
+  Translator?: {
+    create: (options: {
+      sourceLanguage: string;
+      targetLanguage: string;
+    }) => Promise<{
+      translate: (text: string) => Promise<string>;
+    }>;
+  };
+  LanguageDetector?: {
+    create: () => Promise<{
+      detect: (text: string) => Promise<{ detectedLanguage: string }[]>; // Corrected property name here
+    }>;
+  };
+}
+
+declare const self: CustomWindow;
+
+export const useTranslation = (originalText: string) => {
+  const [isApiAvailable, setIsApiAvailable] = useState(false);
+  const [needsTranslation, setNeedsTranslation] = useState(false);
+  const [translatedText, setTranslatedText] = useState<string | null>(null);
+  const [isTranslating, setIsTranslating] = useState(false);
+  const [sourceLang, setSourceLang] = useState<string | null>(null);
+
+  useEffect(() => {
+    if ('Translator' in self && 'LanguageDetector' in self) {
+      setIsApiAvailable(true);
+    } else {
+      console.error('[useTranslation] ERROR: One or both APIs are missing.', {
+          hasTranslator: 'Translator' in self,
+          hasLanguageDetector: 'LanguageDetector' in self
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    setNeedsTranslation(false);
+    setTranslatedText(null);
+    setSourceLang(null);
+
+    if (isApiAvailable && originalText) {
+      const detectLanguage = async () => {
+        try {
+          const detector = await self.LanguageDetector!.create();
+          const results = await detector.detect(originalText);
+
+          if (results.length > 0 && results[0].detectedLanguage) {
+            const detectedCode = results[0].detectedLanguage;
+            
+            if (detectedCode && !detectedCode.startsWith('en')) {
+              setNeedsTranslation(true);
+              setSourceLang(detectedCode);
+            } else {
+            }
+          } else {
+             console.warn('[useTranslation] WARN: Detection returned no results.');
+          }
+        } catch (error) {
+          console.error('[useTranslation] CRITICAL: Language detection failed. Device may be ineligible or another error occurred.', error);
+        }
+      };
+
+      detectLanguage();
+    }
+  }, [originalText, isApiAvailable]);
+
+  const handleTranslate = useCallback(async () => {
+    if (!originalText || !sourceLang) {
+        console.error(`[useTranslation] ERROR: Cannot translate. Missing text or source language. Has text: ${!!originalText}, Has sourceLang: ${!!sourceLang}`);
+        return;
+    }
+
+    console.log(`[useTranslation] Translating from "${sourceLang}"...`);
+    setIsTranslating(true);
+    setTranslatedText(null);
+
+    try {
+      const translator = await self.Translator!.create({
+        sourceLanguage: sourceLang,
+        targetLanguage: 'en'
+      });
+
+      const output = await translator.translate(originalText);
+      setTranslatedText(output);
+      setNeedsTranslation(false);
+    } catch (error) {
+      console.error(`[useTranslation] CRITICAL: Translation from '${sourceLang}' failed.`, error);
+    } finally {
+      setIsTranslating(false);
+    }
+  }, [originalText, sourceLang]);
+
+  return {
+    needsTranslation,
+    isTranslating,
+    translatedText,
+    handleTranslate
+  };
+};


### PR DESCRIPTION
### This PR introduces an **EXPERIMENTAL** "Translate" button on posts.

Very experimental, **opening a PR here only to share with you guys.** Not intending to merge it, but we could eventually polish and merge.

<img width="779" height="401" alt="image" src="https://github.com/user-attachments/assets/3ed9309e-f1b6-4529-8ca1-b67d0acf3e58" />
<img width="776" height="537" alt="image" src="https://github.com/user-attachments/assets/84198562-3c48-4dd2-94c3-d2639d739b31" />

It uses the browser's built-in `LanguageDetector` and `Translator` APIs to provide on-device translations.

The feature automatically detects if a post's content is not in English and displays a "translate" button, allowing users to translate it.

The translation takes place in the user's browser using latest edge AI API recently presented by Google. There is no privacy concerns, data is always local. Translation quality is "acceptable" if the text is not difficult and has no typos. On first translation, the browser will fetch the language model, so it will take a few seconds showing the spinner.

## Limitations
- Browser Support: This is highly experimental and only works on very few supporting browsers (e.g., Chrome 138+).
- Target Language: The translation target is currently hardcoded to English (en). Ideally, we read the target language from the user system or have a setting option to select language.

## TODO 
I leave these to you @flaviomoceri in case we decide we want to merge this feature:
- [ ] Align the spinner, and make the "translate" button prettier.
- [ ] Ideally display the detected language for all posts, e.g. `es` next to the translate button.
- [ ] Allow target language to be other than `en`