### PR TITLE
feat: remove exif metadata from images before upload

### DIFF
--- a/src/components/CreateContent/Section/_FooterArea.tsx
+++ b/src/components/CreateContent/Section/_FooterArea.tsx
@@ -239,7 +239,12 @@ export default function FooterArea({
           } else if (!isImage && !isVideo && file.size > maxOtherSizeInBytes) {
             addAlert('The maximum allowed size is 20 MB', 'warning');
             continue;
-          } else if (isImage && file.type !== 'image/gif' && file.type !== 'image/svg+xml') {
+          } else if (
+            isImage &&
+            file.type !== 'image/gif' &&
+            file.type !== 'image/svg+xml' &&
+            file.type !== 'image/webp'
+          ) {
             try {
               const cleaned = await Utils.stripImageMetadata(file);
               validFiles.push(cleaned);

--- a/src/components/CreateContent/Section/_FooterArea.tsx
+++ b/src/components/CreateContent/Section/_FooterArea.tsx
@@ -239,6 +239,13 @@ export default function FooterArea({
           } else if (!isImage && !isVideo && file.size > maxOtherSizeInBytes) {
             addAlert('The maximum allowed size is 20 MB', 'warning');
             continue;
+          } else if (isImage && file.type !== 'image/gif' && file.type !== 'image/svg+xml') {
+            try {
+              const cleaned = await Utils.stripImageMetadata(file);
+              validFiles.push(cleaned);
+            } catch (e) {
+              validFiles.push(file);
+            }
           } else {
             validFiles.push(file);
           }

--- a/src/components/CreateContent/Section/_InputArea.tsx
+++ b/src/components/CreateContent/Section/_InputArea.tsx
@@ -226,12 +226,12 @@ export default function InputArea({
           } else if (!isImage && !isVideo && file.size > maxOtherSizeInBytes) {
             addAlert('The maximum allowed size is 20 MB', 'warning');
             continue;
-        } else if (
-          isImage &&
-          file.type !== 'image/gif' &&
-          file.type !== 'image/svg+xml' &&
-          file.type !== 'image/webp'
-        ) {
+          } else if (
+            isImage &&
+            file.type !== 'image/gif' &&
+            file.type !== 'image/svg+xml' &&
+            file.type !== 'image/webp'
+          ) {
             try {
               const cleaned = await Utils.stripImageMetadata(file);
               validFiles.push(cleaned);

--- a/src/components/CreateContent/Section/_InputArea.tsx
+++ b/src/components/CreateContent/Section/_InputArea.tsx
@@ -226,6 +226,13 @@ export default function InputArea({
           } else if (!isImage && !isVideo && file.size > maxOtherSizeInBytes) {
             addAlert('The maximum allowed size is 20 MB', 'warning');
             continue;
+          } else if (isImage && file.type !== 'image/gif' && file.type !== 'image/svg+xml') {
+            try {
+              const cleaned = await Utils.stripImageMetadata(file);
+              validFiles.push(cleaned);
+            } catch (e) {
+              validFiles.push(file);
+            }
           } else {
             validFiles.push(file);
           }

--- a/src/components/CreateContent/Section/_InputArea.tsx
+++ b/src/components/CreateContent/Section/_InputArea.tsx
@@ -226,7 +226,12 @@ export default function InputArea({
           } else if (!isImage && !isVideo && file.size > maxOtherSizeInBytes) {
             addAlert('The maximum allowed size is 20 MB', 'warning');
             continue;
-          } else if (isImage && file.type !== 'image/gif' && file.type !== 'image/svg+xml') {
+        } else if (
+          isImage &&
+          file.type !== 'image/gif' &&
+          file.type !== 'image/svg+xml' &&
+          file.type !== 'image/webp'
+        ) {
             try {
               const cleaned = await Utils.stripImageMetadata(file);
               validFiles.push(cleaned);

--- a/src/components/CreateContent/index.tsx
+++ b/src/components/CreateContent/index.tsx
@@ -313,6 +313,13 @@ export default function CreateContent({
                 setIsCompressing(false);
               }
             }
+          } else if (isImage && file.type !== 'image/gif' && file.type !== 'image/svg+xml') {
+            try {
+              const cleaned = await Utils.stripImageMetadata(file);
+              validFiles.push(cleaned);
+            } catch (e) {
+              validFiles.push(file);
+            }
           } else if (isVideo && file.size > maxOtherSizeInBytes) {
             // Check if video is too large for compression
             if (file.size > maxVideoSizeForCompressionInBytes) {

--- a/src/components/CreateContent/index.tsx
+++ b/src/components/CreateContent/index.tsx
@@ -313,7 +313,12 @@ export default function CreateContent({
                 setIsCompressing(false);
               }
             }
-          } else if (isImage && file.type !== 'image/gif' && file.type !== 'image/svg+xml') {
+          } else if (
+            isImage &&
+            file.type !== 'image/gif' &&
+            file.type !== 'image/svg+xml' &&
+            file.type !== 'image/webp'
+          ) {
             try {
               const cleaned = await Utils.stripImageMetadata(file);
               validFiles.push(cleaned);

--- a/src/components/Modal/_CreateArticle/_Content.tsx
+++ b/src/components/Modal/_CreateArticle/_Content.tsx
@@ -249,6 +249,12 @@ export default function ContentCreateArticle({
         } finally {
           setIsCompressing(false);
         }
+      } else if (isImage && file.type !== 'image/gif' && file.type !== 'image/svg+xml') {
+        try {
+          processedFile = await Utils.stripImageMetadata(file);
+        } catch (e) {
+          // keep original on failure
+        }
       } else if (isVideo && file.size > maxOtherSizeInBytes) {
         // Check if video is too large for compression
         if (file.size > maxVideoSizeForCompressionInBytes) {
@@ -377,6 +383,12 @@ export default function ContentCreateArticle({
             return;
           } finally {
             setIsCompressing(false);
+          }
+        } else if (isImage) {
+          try {
+            processedFile = await Utils.stripImageMetadata(file);
+          } catch (e) {
+            // keep original on failure
           }
         } else if (isVideo && file.size > maxOtherSizeInBytes) {
           // Check if video is too large for compression

--- a/src/components/Modal/_CreateArticle/_Content.tsx
+++ b/src/components/Modal/_CreateArticle/_Content.tsx
@@ -249,7 +249,12 @@ export default function ContentCreateArticle({
         } finally {
           setIsCompressing(false);
         }
-      } else if (isImage && file.type !== 'image/gif' && file.type !== 'image/svg+xml') {
+      } else if (
+        isImage &&
+        file.type !== 'image/gif' &&
+        file.type !== 'image/svg+xml' &&
+        file.type !== 'image/webp'
+      ) {
         try {
           processedFile = await Utils.stripImageMetadata(file);
         } catch (e) {
@@ -384,7 +389,12 @@ export default function ContentCreateArticle({
           } finally {
             setIsCompressing(false);
           }
-        } else if (isImage) {
+        } else if (
+          isImage &&
+          file.type !== 'image/gif' &&
+          file.type !== 'image/svg+xml' &&
+          file.type !== 'image/webp'
+        ) {
           try {
             processedFile = await Utils.stripImageMetadata(file);
           } catch (e) {

--- a/src/components/Modal/_CreateArticle/_Content.tsx
+++ b/src/components/Modal/_CreateArticle/_Content.tsx
@@ -249,12 +249,7 @@ export default function ContentCreateArticle({
         } finally {
           setIsCompressing(false);
         }
-      } else if (
-        isImage &&
-        file.type !== 'image/gif' &&
-        file.type !== 'image/svg+xml' &&
-        file.type !== 'image/webp'
-      ) {
+      } else if (isImage && file.type !== 'image/gif' && file.type !== 'image/svg+xml' && file.type !== 'image/webp') {
         try {
           processedFile = await Utils.stripImageMetadata(file);
         } catch (e) {

--- a/src/components/utils-shared/index.ts
+++ b/src/components/utils-shared/index.ts
@@ -27,6 +27,7 @@ import genJdenticon from './lib/Helper/genJdenticon';
 import sanitizeUrlsArticle from './lib/Helper/sanitizeUrlsArticle';
 import { resizeImageFile } from './lib/Helper/resizeImageFile';
 import { resizeVideoFile } from './lib/Helper/resizeVideoFile';
+import { stripImageMetadata } from './lib/Helper/stripImageMetadata';
 import { censoredTags } from './lib/Helper/Moderation/censoredTags';
 import isPostCensored from './lib/Helper/Moderation/isPostCensored';
 import isProfileCensored from './lib/Helper/Moderation/isProfileCensored';
@@ -65,5 +66,6 @@ export const Utils = {
   genJdenticon,
   sanitizeUrlsArticle,
   resizeImageFile,
-  resizeVideoFile
+  resizeVideoFile,
+  stripImageMetadata
 };

--- a/src/components/utils-shared/lib/Helper/stripImageMetadata.ts
+++ b/src/components/utils-shared/lib/Helper/stripImageMetadata.ts
@@ -1,0 +1,45 @@
+export async function stripImageMetadata(file: File): Promise<File> {
+  const supportedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+  const outputType = supportedTypes.includes(file.type) ? file.type : 'image/jpeg';
+
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      if (!reader.result) {
+        reject(new Error('No file data'));
+        return;
+      }
+      img.src = reader.result as string;
+    };
+
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth || img.width;
+      canvas.height = img.naturalHeight || img.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('No canvas context'));
+        return;
+      }
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          reject(new Error('Failed to create blob'));
+          return;
+        }
+        const cleanFile = new File([blob], file.name, {
+          type: outputType,
+          lastModified: Date.now()
+        });
+        resolve(cleanFile);
+      }, outputType);
+    };
+
+    img.onerror = () => reject(new Error('Failed to load image'));
+    reader.onerror = () => reject(new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}


### PR DESCRIPTION
resolves https://github.com/pubky/pubky-app/issues/1834

This ensures images that are attached to content without being compressed are without metadata.
Compressed images already get re-encoded and profile images get cropped, so they are both already EXIF-free.