### PR TITLE
fix: link preview in posts

### DIFF
--- a/src/components/Post/_Content.tsx
+++ b/src/components/Post/_Content.tsx
@@ -202,7 +202,7 @@ export default function Content({
                     ></iframe>
                   </div>
                 )}
-                {preview && !videoId && !tweetId && !githubUrl && !spotifyUrl && !blueskyUrl && (
+                {preview && !videoId && !tweetId && !githubUrl && !spotifyUrl && !blueskyUrl.url && (
                   <div onClick={(event) => event.stopPropagation()}>
                     <LinkPreview url={preview} />
                   </div>


### PR DESCRIPTION
Fixes bug that prevents most link previews from displaying. Was introduced when recent work was done to support bluesky link previews.

Fixes https://github.com/pubky/pubky-app/issues/1897

-----

Before
<img width="793" height="246" alt="Screenshot 2025-10-30 at 11 25 20" src="https://github.com/user-attachments/assets/27380e2c-2f2f-4026-a8b5-521fc2cbdd4d" />

After
<img width="786" height="442" alt="Screenshot 2025-10-30 at 11 25 25" src="https://github.com/user-attachments/assets/1c7da3bf-0304-49e4-9970-084ebab81f0c" />

-----

Before
<img width="786" height="473" alt="Screenshot 2025-10-30 at 11 26 12" src="https://github.com/user-attachments/assets/562ed15b-9e19-48b3-a4d8-d02cc760796d" />

After
<img width="791" height="678" alt="Screenshot 2025-10-30 at 11 25 43" src="https://github.com/user-attachments/assets/f368970b-dfb0-4aeb-93ee-29ed73db626b" />
