### PR TITLE
fix: ensure YouTube domain when parsing inline url

### DIFF
--- a/src/hooks/useInlineUrls.ts
+++ b/src/hooks/useInlineUrls.ts
@@ -490,6 +490,10 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
 
       // YouTube video detection
       const getYouTubeID = (url: string): string | null => {
+        // Only process URLs that are actually from YouTube domains
+        if (!/youtube\.com|youtu\.be/.test(url)) {
+          return null;
+        }
         const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
         const match = url.match(regExp);
         return match && match[2].length === 11 ? match[2] : null;


### PR DESCRIPTION
**Before**
<img width="779" height="755" alt="Screenshot 2025-11-05 at 08 45 59" src="https://github.com/user-attachments/assets/ea999468-0c77-45a6-a910-812256dcd2f6" />


**After**

<img width="782" height="418" alt="Screenshot 2025-11-05 at 08 45 50" src="https://github.com/user-attachments/assets/5a69e52d-7e8f-4434-a412-5f50d975ffaa" />
