### PR TITLE
fix: remove unnecessary copy-to-clipboard when deeplinking to pubky-ring

### DIFF
--- a/src/app/sign-in/Card/_SignIn.tsx
+++ b/src/app/sign-in/Card/_SignIn.tsx
@@ -197,7 +197,6 @@ export default function SignIn() {
           onClick={
             authUrl
               ? () => {
-                  copyToClipboard();
                   openApp();
                 }
               : undefined


### PR DESCRIPTION
The problem is the sign in flow on mobile with pubky-ring clears user's existing clipboard without warning.

Thie PR removes the unnecessary copy during this sign in flow, it passes auth url to pubky-ring with use of deep-link.

Copy action still exists when clicking QR on desktop, see https://github.com/pubky/pubky-app/blob/2c59c4e3308ae7f8c2c475845d020e3bb5307ee6/src/app/sign-in/Card/_SignIn.tsx#L139-L140