### PR TITLE
feat: YouTube timestamp support in embedded player

### DIFF
--- a/src/components/LinkPreview/index.tsx
+++ b/src/components/LinkPreview/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import getYouTubeID from 'get-youtube-id';
+import { useEffect, useMemo, useState } from 'react';
 import { Tweet } from 'react-tweet';
 import { Preview, Post as PostUI } from '@social/ui-shared';
 import { usePubkyClientContext } from '@/contexts';
@@ -22,7 +21,7 @@ export default function LinkPreviewer({ content, setQuote }: LinkPreviewerProps)
   const [debounceTimeout, setDebounceTimeout] = useState<NodeJS.Timeout | null>(null);
 
   // Use the useInlineUrls hook for URL detection
-  const { preview, videoId, tweetId, githubUrl, spotifyUrl, blueskyUrl } = useInlineUrls({ text: content });
+  const { preview, videoId, videoStart, tweetId, githubUrl, spotifyUrl, blueskyUrl } = useInlineUrls({ text: content });
 
   const checkForPubkyPost = (text: string) => {
     if (debounceTimeout) {
@@ -112,6 +111,19 @@ export default function LinkPreviewer({ content, setQuote }: LinkPreviewerProps)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [content]);
 
+  const youtubeEmbedSrc = useMemo(() => {
+    if (!videoId) {
+      return '';
+    }
+
+    const params = new URLSearchParams({ enablejsapi: '1' });
+    if (videoStart > 0) {
+      params.set('start', videoStart.toString());
+    }
+
+    return `https://www.youtube.com/embed/${videoId}?${params.toString()}`;
+  }, [videoId, videoStart]);
+
   return (
     <>
       {postPreview && (
@@ -119,12 +131,12 @@ export default function LinkPreviewer({ content, setQuote }: LinkPreviewerProps)
           <Post post={postPreview} repostView postType="single" />
         </div>
       )}
-      {videoId && (
+      {videoId && youtubeEmbedSrc && (
         <div className="relative w-full border border-stone-800 hover:border-stone-700 mt-4 rounded-xl overflow-hidden">
           <iframe
             width="100%"
             height="315"
-            src={`https://www.youtube.com/embed/${videoId}?enablejsapi=1`}
+            src={youtubeEmbedSrc}
             title="YouTube video player"
             allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen

--- a/src/components/Post/_Content.tsx
+++ b/src/components/Post/_Content.tsx
@@ -3,7 +3,7 @@
 import { Utils } from '@social/utils-shared';
 import LinkPreview from '@/components/ui-shared/lib/Post/_Preview';
 import { GitHub } from '@/components/ui-shared/lib/Preview/Github';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Tweet } from 'react-tweet';
 import Parsing from '../Content/_Parsing';
 import { Button, Icon, Skeleton, Typography } from '@social/ui-shared';
@@ -52,6 +52,7 @@ export default function Content({
     fileContents: externalFileContents,
     preview,
     videoId,
+    videoStart,
     tweetId,
     githubUrl,
     spotifyUrl,
@@ -62,6 +63,19 @@ export default function Content({
     files,
     externalFileContents
   });
+
+  const youtubeEmbedSrc = useMemo(() => {
+    if (!videoId) {
+      return '';
+    }
+
+    const params = new URLSearchParams({ enablejsapi: '1' });
+    if (videoStart > 0) {
+      params.set('start', videoStart.toString());
+    }
+
+    return `https://www.youtube.com/embed/${videoId}?${params.toString()}`;
+  }, [videoId, videoStart]);
 
   useEffect(() => {
     if (post?.details?.uri && isCensored) {
@@ -187,7 +201,7 @@ export default function Content({
           <div>
             {!replyView && String(post?.details?.kind) !== PubkyAppPostKind[1].toLocaleLowerCase() && (
               <div>
-                {videoId && (
+                {videoId && youtubeEmbedSrc && (
                   <div
                     onClick={(event) => event.stopPropagation()}
                     className="w-full max-w-[560px] relative border border-stone-800 hover:border-stone-700 mt-4 rounded-xl overflow-hidden"
@@ -195,7 +209,7 @@ export default function Content({
                     <iframe
                       width="100%"
                       height="315"
-                      src={`https://www.youtube.com/embed/${videoId}?enablejsapi=1`}
+                      src={youtubeEmbedSrc}
                       title="YouTube video player"
                       allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                       allowFullScreen

--- a/src/hooks/useInlineUrls.ts
+++ b/src/hooks/useInlineUrls.ts
@@ -310,7 +310,7 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
   const extractYouTubeDetails = (rawUrl: string): { id: string | null; start: number } => {
     // Only process URLs that are actually from YouTube domains
     if (!/youtube\.com|youtu\.be/.test(rawUrl)) {
-      return null;
+      return { id: null, start: 0 };
     }
 
     const regExp = /^.*(youtu.be\/(?!shorts)|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;

--- a/src/hooks/useInlineUrls.ts
+++ b/src/hooks/useInlineUrls.ts
@@ -298,27 +298,13 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
     return text?.replace(/\n{3,}/g, '\n\n');
   };
 
-  const parseYouTubeTime = (value: string | null): number => {
+  const parseYouTubeSeconds = (value: string | null): number => {
     if (!value) {
       return 0;
     }
 
-    if (/^\d+$/.test(value)) {
-      return parseInt(value, 10);
-    }
-
-    const timePattern = /(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)(?:s)?)?/i;
-    const match = value.match(timePattern);
-    if (!match) {
-      return 0;
-    }
-
-    const hours = match[1] ? parseInt(match[1], 10) : 0;
-    const minutes = match[2] ? parseInt(match[2], 10) : 0;
-    const seconds = match[3] ? parseInt(match[3], 10) : 0;
-
-    const totalSeconds = hours * 3600 + minutes * 60 + seconds;
-    return Number.isNaN(totalSeconds) ? 0 : totalSeconds;
+    const parsed = parseInt(value, 10);
+    return Number.isNaN(parsed) || parsed < 0 ? 0 : parsed;
   };
 
   const extractYouTubeDetails = (rawUrl: string): { id: string | null; start: number } => {
@@ -337,7 +323,7 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
       if (start > 0) {
         return;
       }
-      const parsed = parseYouTubeTime(value);
+      const parsed = parseYouTubeSeconds(value);
       if (parsed > 0) {
         start = parsed;
       }
@@ -346,30 +332,21 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
     try {
       const parsedUrl = new URL(rawUrl);
       setStartFromValue(parsedUrl.searchParams.get('t'));
-      setStartFromValue(parsedUrl.searchParams.get('start'));
 
       if (!start && parsedUrl.hash) {
         const hash = parsedUrl.hash.replace(/^#/, '');
-
         if (hash.startsWith('t=')) {
           setStartFromValue(hash.substring(2));
         } else {
           const hashParams = new URLSearchParams(hash);
           setStartFromValue(hashParams.get('t'));
-          setStartFromValue(hashParams.get('start'));
         }
       }
     } catch {
       const queryMatch = rawUrl.match(/[?&#]t=([^&#]+)/i);
       setStartFromValue(queryMatch ? queryMatch[1] : null);
-
       if (start === 0) {
-        const startMatch = rawUrl.match(/[?&#]start=([^&#]+)/i);
-        setStartFromValue(startMatch ? startMatch[1] : null);
-      }
-
-      if (start === 0) {
-        const hashMatch = rawUrl.match(/#t=([^&#]+)/i) || rawUrl.match(/#start=([^&#]+)/i);
+        const hashMatch = rawUrl.match(/#t=([^&#]+)/i);
         setStartFromValue(hashMatch ? hashMatch[1] : null);
       }
     }

--- a/src/hooks/useInlineUrls.ts
+++ b/src/hooks/useInlineUrls.ts
@@ -11,6 +11,7 @@ interface UseInlineUrlsReturn {
   loading: boolean;
   preview: string;
   videoId: string;
+  videoStart: number;
   tweetId: string;
   githubUrl: string;
   spotifyUrl: string;
@@ -26,6 +27,7 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
   const [loading, setLoading] = useState(true);
   const [preview, setPreview] = useState('');
   const [videoId, setVideoId] = useState('');
+  const [videoStart, setVideoStart] = useState(0);
   const [tweetId, setTweetId] = useState('');
   const [githubUrl, setGithubUrl] = useState('');
   const [spotifyUrl, setSpotifyUrl] = useState('');
@@ -296,6 +298,85 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
     return text?.replace(/\n{3,}/g, '\n\n');
   };
 
+  const parseYouTubeTime = (value: string | null): number => {
+    if (!value) {
+      return 0;
+    }
+
+    if (/^\d+$/.test(value)) {
+      return parseInt(value, 10);
+    }
+
+    const timePattern = /(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)(?:s)?)?/i;
+    const match = value.match(timePattern);
+    if (!match) {
+      return 0;
+    }
+
+    const hours = match[1] ? parseInt(match[1], 10) : 0;
+    const minutes = match[2] ? parseInt(match[2], 10) : 0;
+    const seconds = match[3] ? parseInt(match[3], 10) : 0;
+
+    const totalSeconds = hours * 3600 + minutes * 60 + seconds;
+    return Number.isNaN(totalSeconds) ? 0 : totalSeconds;
+  };
+
+  const extractYouTubeDetails = (rawUrl: string): { id: string | null; start: number } => {
+    // Only process URLs that are actually from YouTube domains
+    if (!/youtube\.com|youtu\.be/.test(rawUrl)) {
+      return null;
+    }
+
+    const regExp = /^.*(youtu.be\/(?!shorts)|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
+    const match = rawUrl.match(regExp);
+    const id = match && match[2].length === 11 ? match[2] : null;
+
+    let start = 0;
+
+    const setStartFromValue = (value: string | null) => {
+      if (start > 0) {
+        return;
+      }
+      const parsed = parseYouTubeTime(value);
+      if (parsed > 0) {
+        start = parsed;
+      }
+    };
+
+    try {
+      const parsedUrl = new URL(rawUrl);
+      setStartFromValue(parsedUrl.searchParams.get('t'));
+      setStartFromValue(parsedUrl.searchParams.get('start'));
+
+      if (!start && parsedUrl.hash) {
+        const hash = parsedUrl.hash.replace(/^#/, '');
+
+        if (hash.startsWith('t=')) {
+          setStartFromValue(hash.substring(2));
+        } else {
+          const hashParams = new URLSearchParams(hash);
+          setStartFromValue(hashParams.get('t'));
+          setStartFromValue(hashParams.get('start'));
+        }
+      }
+    } catch {
+      const queryMatch = rawUrl.match(/[?&#]t=([^&#]+)/i);
+      setStartFromValue(queryMatch ? queryMatch[1] : null);
+
+      if (start === 0) {
+        const startMatch = rawUrl.match(/[?&#]start=([^&#]+)/i);
+        setStartFromValue(startMatch ? startMatch[1] : null);
+      }
+
+      if (start === 0) {
+        const hashMatch = rawUrl.match(/#t=([^&#]+)/i) || rawUrl.match(/#start=([^&#]+)/i);
+        setStartFromValue(hashMatch ? hashMatch[1] : null);
+      }
+    }
+
+    return { id, start };
+  };
+
   // Helper function to extract Bluesky post parameters from URL
   const extractBlueskyParams = (url: string): { handle: string; rkey: string } | null => {
     try {
@@ -489,18 +570,11 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
       }
 
       // YouTube video detection
-      const getYouTubeID = (url: string): string | null => {
-        // Only process URLs that are actually from YouTube domains
-        if (!/youtube\.com|youtu\.be/.test(url)) {
-          return null;
-        }
-        const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
-        const match = url.match(regExp);
-        return match && match[2].length === 11 ? match[2] : null;
-      };
-
-      const youtubeId = getYouTubeID(url);
-      if (youtubeId) setVideoId(youtubeId);
+      const { id: youtubeId, start: youtubeStart } = extractYouTubeDetails(url);
+      if (youtubeId) {
+        setVideoId(youtubeId);
+        setVideoStart(youtubeStart);
+      }
 
       // Twitter/X detection
       const twitterRegex = /https?:\/\/(?:www\.)?(?:twitter\.com|x\.com)\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)/;
@@ -549,6 +623,7 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
     // Reset all URL states when text changes
     setPreview('');
     setVideoId('');
+    setVideoStart(0);
     setTweetId('');
     setGithubUrl('');
     setSpotifyUrl('');
@@ -569,6 +644,7 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
     loading,
     preview,
     videoId,
+    videoStart,
     tweetId,
     githubUrl,
     spotifyUrl,


### PR DESCRIPTION
Support timestamps in the embedded YT player with format `t=1234` like https://youtu.be/lXUZvyajciY?t=1833.
No support for timestamp using hours, minutes and seconds.