### PR TITLE
fix: handle new homeservers 404 response to empty feeds dir

### DIFF
--- a/src/contexts/_pubky.tsx
+++ b/src/contexts/_pubky.tsx
@@ -1443,11 +1443,22 @@ export function PubkyClientWrapper({ children }: { children: React.ReactNode }) 
   );
 
   const loadFeeds = withAuth(async (): Promise<{ feed: ICustomFeed; name: string }[]> => {
-    // Define the feeds directory path
     const feedsDirUrl = `pubky://${pubky}/pub/pubky.app/feeds/`;
-    const feedUris = await client.list(feedsDirUrl);
+    let feedUris: string[] = [];
 
-    // Fetch each feed data
+    try {
+      feedUris = await client.list(feedsDirUrl);
+    } catch (error) {
+      if (error.toString().includes('404')) {
+        return [];
+      }
+      throw error;
+    }
+
+    if (feedUris.length === 0) {
+      return [];
+    }
+
     const feedsData = await Promise.all(
       feedUris.map(async (uri) => {
         try {


### PR DESCRIPTION
Since homeserver migration to postgres its behaviour has changed to return 404 when its `feeds` dir is empty, which is the case for every new user. In pubky-app, the consequence of this is inability to add custom feeds (the array was not being initialised and therefore the add custom feed button did not render, and adding feed on mobile would hang).

**before**
<img width="506" height="269" alt="Screenshot 2025-11-14 at 15 07 32" src="https://github.com/user-attachments/assets/8565408c-0ed4-49e8-8d02-11fbf313be69" />