### PR TITLE
fix: only filter out pubky.app url for link preview

### DIFF
--- a/src/hooks/useInlineUrls.ts
+++ b/src/hooks/useInlineUrls.ts
@@ -539,8 +539,13 @@ export const useInlineUrls = ({ text, files }: UseInlineUrlsProps): UseInlineUrl
       const firstUrl = allUrls.sort((a, b) => a.index - b.index)[0];
       const url = firstUrl.url;
 
-      const postRegex = new RegExp(`/post/([^/]+)/([^/]+)`);
-      if (postRegex.test(url)) return;
+      // Only filter out Pubky internal post URLs, not external URLs with /post/ in path
+      if (isValidUrl(url)) {
+        const parsedUrl = new URL(url);
+        const isPubkyDomain = parsedUrl.hostname === 'pubky.app' || parsedUrl.hostname.endsWith('.pubky.app');
+        const postRegex = new RegExp(`/post/([^/]+)/([^/]+)`);
+        if (isPubkyDomain && postRegex.test(url)) return;
+      }
 
       if (!isImageUrl(url) && !isVideoUrl(url) && !isAudioUrl(url) && !isPdfUrl(url) && !isInternalPubkyUrl(url)) {
         setPreview(url);


### PR DESCRIPTION
This PR enables parsing link preview for urls that contain `/post/` e.g. https://www.theblock.co/post/379176/el-salvador-100-million-bitcoin-purchase

Now it attempts to get link preview, however there is a deeper problem:  theblock uses cloudflare to block our request `Error: Request failed with status 403`.  This is possibly because we're using node.js to request the data rather than the browser, so the bot filters us out. I don't think theblock offer a proper api like twitter do so not sure how to resolve.

-----

I added more logging and this is the full response:

```
Preview fetch failed for https://www.theblock.co/post/379176/el-salvador-100-million-bitcoin-purchase/: {
  status: 403,
  statusText: 'Forbidden',
  headers: {
    'cache-control': 'private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0',
    'cf-ray': '9a06aeb05834001e-LHR',
    connection: 'keep-alive',
    'content-encoding': 'br',
    'content-type': 'text/html; charset=UTF-8',
    date: 'Tue, 18 Nov 2025 10:11:12 GMT',
    expires: 'Thu, 01 Jan 1970 00:00:01 GMT',
    'permissions-policy': 'microphone=(), camera=()',
    'referrer-policy': 'same-origin, strict-origin-when-cross-origin',
    server: 'cloudflare',
    'set-cookie': '__cf_bm=CoaVaFGIPvcpVloT6AZotK9S2T4Zl3BPas1N36jZ6mY-1763460672-1.0.1.1-yMmR0O2JvJDteF8e9SQK9DfJHZUWujmQIm9cQv6cq9aOEz7rTl2wH.jgWKpfJyV6dNIqz_xaRV70HgqRwqX.aVJMJvVHAgxU_TqYYiYOX0Q; path=/; expires=Tue, 18-Nov-25 10:41:12 GMT; domain=.theblock.co; HttpOnly; Secure; SameSite=None',
    'strict-transport-security': 'max-age=31536000; includeSubDomains; preload',
    'transfer-encoding': 'chunked',
    vary: 'Accept-Encoding',
    'x-content-type-options': 'nosniff',
    'x-frame-options': 'SAMEORIGIN'
  },
  errorBody: '<!DOCTYPE html>\n' +
    '<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]-->\n' +
    '<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en-US"> <![endif]-->\n' +
    '<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en-US"> <![endif]-->\n' +
    '<!--[if gt IE 8]><!--> <html class="no-js" lang="en-US"> <!--<![endif]-->\n' +
    '<head>\n' +
    '<title>Attention Required! | Cloudflare</title>\n' +
    '<meta charset="UTF-8" />\n' +
    '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />\n' +
    '<meta http-equiv="X-UA-Compatible" '
}
Error fetching URL: Error: Request failed with status 403: Forbidden
    at GET (src/app/api/preview/route.ts:81:12)
  79 |         errorBody: errorText.substring(0, 500) // First 500 chars of error response
  80 |       });
> 81 |       throw new Error(`Request failed with status ${response.status}: ${response.statusText}`);
     |            ^
  82 |     }
  83 |
  84 |     const html = await response.text();
 GET /api/preview?url=https%3A%2F%2Fwww.theblock.co%2Fpost%2F379176%2Fel-salvador-100-million-bitcoin-purchase%2F 403 in 101ms
```

