### PR TITLE
fix: increase query limit for posts on timeline to mitigate issue #1787

### DIFF
--- a/src/app/home/components/_Timeline.tsx
+++ b/src/app/home/components/_Timeline.tsx
@@ -26,7 +26,7 @@ export const Timeline = () => {
   const [skip, setSkip] = useState<number>(0);
   const [isLoading, setIsLoading] = useState(true);
   const [finishedLoading, setFinishedLoading] = useState(false);
-  const limit = 10;
+  const limit = 25;
 
   const fetchPosts = async ({
     skipValue = skip,


### PR DESCRIPTION
hopefully helps enough with the blank feed seen when muted user fills post stream query response