### PR TITLE
fix: show placeholder when link preview blocked (403 cloudflare)

### DIFF
--- a/src/app/api/preview/route.ts
+++ b/src/app/api/preview/route.ts
@@ -77,6 +77,12 @@ export async function GET(request: Request) {
     });
 
     if (!response.ok) {
+      // For 403 errors (Cloudflare protection), return a placeholder with domain name
+      if (response.status === 403) {
+        return NextResponse.json({
+          title: parsedUrl.hostname.replace(/^www\./, '')
+        });
+      }
       throw new Error(`Request failed with status ${response.status}`);
     }
 

--- a/src/components/ui-shared/lib/Post/_Preview.tsx
+++ b/src/components/ui-shared/lib/Post/_Preview.tsx
@@ -49,6 +49,18 @@ function LinkPreview({ url }: { url: string }) {
           return;
         }
 
+        // Handle blocked URLs (403 from Cloudflare) - show placeholder with domain
+        if (data.blocked) {
+          const domain = data.title || new URL(url).hostname.replace(/^www\./, '');
+          setPreviewData({
+            title: domain,
+            description: '',
+            image: null
+          });
+          setLoading(false);
+          return;
+        }
+
         const validImage = data.image ? await isValidImage(data.image) : false;
 
         const preview = {


### PR DESCRIPTION
Always show placeholder link preview when blocked - i.e. when Cloudflare forbid us 403

**Before**
<img width="773" height="209" alt="Screenshot 2025-11-25 at 20 10 02" src="https://github.com/user-attachments/assets/089da0c6-17ab-443a-a261-46c3a0bf4a91" />


**After**
<img width="771" height="352" alt="Screenshot 2025-11-25 at 20 09 26" src="https://github.com/user-attachments/assets/fbf6d5a7-4ec5-4ad5-968d-d0ea459588a7" />
